### PR TITLE
Load the Emscripten port of SplashKit in the IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+temp/

--- a/Browser_IDE/Api.js
+++ b/Browser_IDE/Api.js
@@ -2,12 +2,12 @@ const express = require("express")
 const app = express()
 const bodyP = require("body-parser")
 const compiler = require("compilex")
+var path = require('path');
 const options = { stats: true }
 compiler.init(options)
 app.use(bodyP.json())
 
-// change this to the path of your codemirror folder before running the server
-app.use("/codemirror-5.65.15", express.static("E:\Code\web-editor\CodeEditor\codemirror-5.65.15"))
+app.use("/codemirror-5.65.15", express.static(path.join(__dirname,"node_modules/codemirror")))
 
 app.use(function (req, res, next) {
     res.header("Access-Control-Allow-Origin", "*");
@@ -19,13 +19,14 @@ app.use(function (req, res, next) {
     next();
   });
 
+app.use(express.static(path.join(__dirname,"")));
+
 app.get("/", function (req, res) {
     compiler.flush(function () {
         console.log("deleted")
     })
 
-    // change this to the path of your index.html file before running the server
-    res.sendFile("E:\Code\web-editor\CodeEditor\index.html")
+    res.sendFile("index.html", { root: __dirname })
 })
 app.post("/compile", function (req, res) {
     var code = req.body.code

--- a/Browser_IDE/fsevents.js
+++ b/Browser_IDE/fsevents.js
@@ -1,0 +1,125 @@
+"use strict";
+
+let FSEvents = new EventTarget();
+
+// File System Delegate Initialization
+moduleEvents.addEventListener("onRuntimeInitialized", function() {
+    // Attach to file system callbacks
+    FS.trackingDelegate['willMovePath'] = function(oldpath, newpath) {
+        let ev = new Event("willMovePath");
+        ev.oldpath = oldpath;
+        ev.newpath = newpath;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onMovePath'] = function(oldpath, newpath) {
+        let ev = new Event("onMovePath");
+        ev.oldpath = oldpath;
+        ev.newpath = newpath;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['willDeletePath'] = function(path) {
+        let ev = new Event("willDeletePath");
+        ev.path = path;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onDeletePath'] = function(path) {
+        let ev = new Event("onDeletePath");
+        ev.path = path;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onOpenFile'] = function(path, flags) {
+        let ev = new Event("onOpenFile");
+        ev.path = path;
+        ev.flags = flags;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onReadFile'] = function(path, bytesRead) {
+        let ev = new Event("onReadFile");
+        ev.path = path;
+        ev.bytesRead = bytesRead;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onWriteToFile'] = function(path, bytesWritten) {
+        let ev = new Event("onWriteToFile");
+        ev.path = path;
+        ev.bytesWritten = bytesWritten;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onSeekFile'] = function(path, position, whence) {
+        let ev = new Event("onSeekFile");
+        ev.path = path;
+        ev.position = position;
+        ev.whence = whence;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onCloseFile'] = function(path) {
+        let ev = new Event("onCloseFile");
+        ev.path = path;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onMakeDirectory'] = function(path, mode) {
+        let ev = new Event("onMakeDirectory");
+        ev.path = path;
+        ev.mode = mode;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onMakeSymlink'] = function(oldpath, newpath) {
+        let ev = new Event("onMakeSymlink");
+        ev.oldpath = oldpath;
+        ev.newpath = newpath;
+        FSEvents.dispatchEvent(ev);
+    };
+});
+
+function TestFSEvents()
+{
+    FSEvents.addEventListener('willMovePath', function(e) {
+        console.log('About to move "' + e.oldpath + '" to "' + e.newpath + '"');
+    });
+    FSEvents.addEventListener('onMovePath', function(e) {
+        console.log('Moved "' + e.oldpath + '" to "' + e.newpath + '"');
+    });
+    FSEvents.addEventListener('willDeletePath', function(e) {
+        console.log('About to delete "' + e.path + '"');
+    });
+    FSEvents.addEventListener('onDeletePath', function(e) {
+        console.log('Deleted "' + e.path + '"');
+    });
+    FSEvents.addEventListener('onOpenFile', function(e) {
+        console.log('Opened "' + e.path + '" with flags ' + e.flags);
+    });
+    FSEvents.addEventListener('onReadFile', function(e) {
+        console.log('Read ' + e.bytesRead + ' bytes from "' + e.path + '"');
+    });
+    FSEvents.addEventListener('onWriteToFile', function(e) {
+        console.log('Wrote to file "' + e.path + '" with ' + e.bytesWritten + ' bytes written');
+    });
+    FSEvents.addEventListener('onSeekFile', function(e) {
+        console.log('Seek on "' + e.path + '" with position ' + e.position + ' and whence ' + e.whence);
+    });
+    FSEvents.addEventListener('onCloseFile', function(e) {
+        console.log('Closed ' + e.path);
+    });
+    FSEvents.addEventListener('onMakeDirectory', function(e) {
+        console.log('Created directory ' + e.path + ' with mode ' + e.mode);
+    });
+    FSEvents.addEventListener('onMakeSymlink', function(e) {
+        console.log('Created symlink from ' + e.oldpath + ' to ' + e.newpath);
+    });
+
+    FS.mkdir("/testDir");
+    FS.rename("/testDir","/testDirRnm");
+    FS.rmdir("/testDirRnm");
+    FS.writeFile('/testFile.txt', 'Hello World!');
+    FS.readFile('/testFile.txt');
+    FS.symlink("/testFile.txt", "/testFileRenamed.txt");
+
+    let stream = FS.open("/testFileRenamed.txt", "r");
+    FS.llseek(stream, 6, 0);
+    let buf = new Uint8Array(5);
+    FS.read(stream, buf, 0, 5, 0);
+    FS.close(stream);
+
+    FS.unlink("/testFileRenamed.txt");
+    FS.unlink("/testFile.txt");
+}

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -60,6 +60,7 @@
 </body>
 
 <script src="loadsplashkit.js"></script>
+<script src="fsevents.js"></script>
 <script src="script.js"></script>
 <script src="splashkit/SplashKitBackendWASM.js"></script>
 </html>

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -42,19 +42,25 @@
             <textarea type="text" id="editor" class="form-control" aria-label="First name"></textarea>
         </div>
         <div class="col d-flex flex-column rounded bg-dark px-4">
-            <div class="h-50">
-                <label for="Input" class="text-light mt-4 mb-2">Input</label>
-                <textarea type="text" id="input" class="form-control h-75" aria-label="Last name"></textarea>
-            </div>
-            <div class="h-50">
-                <label for="Output" class="text-light mb-2">Output</label>
-                <textarea type="text" id="output" class="form-control h-75" aria-label="Last name"></textarea>
+            <div class="col d-flex flex-column rounded bg-dark px-4 justify-content-center flex-grow-1" >
+                <figure style="" id="spinner"><div></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
+                <div id="status">Downloading...</div>
+                <div>
+                  <progress value="0" max="100" id="progress" hidden=1></progress>
+                </div>
+                <div class="row m-3">
+                  <canvas id="canvas" style="vertical-align:center; max-width: 100%; width:inherit;" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+                </div>
+                <div class="row m-3">
+                    <textarea id="output"  readonly style="height:16em; background-color:#282a36; color:#f8f8f2; border:none;"></textarea>
+                </div>
             </div>
         </div>
     </div>
 </body>
 
+<script src="loadsplashkit.js"></script>
 <script src="script.js"></script>
-
+<script src="splashkit/SplashKitBackendWASM.js"></script>
 </html>
 <!-- Sherap's work ends here -->

--- a/Browser_IDE/loadsplashkit.js
+++ b/Browser_IDE/loadsplashkit.js
@@ -1,0 +1,79 @@
+"use strict";
+
+let statusElement = document.getElementById('status');
+let progressElement = document.getElementById('progress');
+let spinnerElement = document.getElementById('spinner');
+
+var Module = {
+    print: (function() {
+        let element = document.getElementById('output');
+        if (element) element.value = ''; // clear browser cache
+        return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+                element.value += text + "\n";
+                element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+        };
+    })(),
+    canvas: (() => {
+        let canvas = document.getElementById('canvas');
+
+        // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+        // application robust, you may want to override this behavior before shipping!
+        // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+        canvas.addEventListener("webglcontextlost", (e) => { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+        return canvas;
+    })(),
+    setStatus: (text) => {
+        if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+        if (text === Module.setStatus.last.text) return;
+        let m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+        let now = Date.now();
+        if (m && now - Module.setStatus.last.time < 30) return; // if this is a progress update, skip it if too soon
+        Module.setStatus.last.time = now;
+        Module.setStatus.last.text = text;
+        if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+        } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.hidden = true;
+        }
+        statusElement.innerHTML = text;
+    },
+    totalDependencies: 0,
+    monitorRunDependencies: (left) => {
+        this.totalDependencies = Math.max(this.totalDependencies, left);
+        Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+    },
+    preRun: (function() {
+        ENV.SDL_EMSCRIPTEN_KEYBOARD_ELEMENT = "canvas";
+    }),
+};
+
+Module.setStatus('Downloading...');
+window.onerror = () => {
+    Module.setStatus('Exception thrown, see JavaScript console');
+    spinnerElement.style.display = 'none';
+    Module.setStatus = (text) => {
+        if (text) console.error('[post-exception status] ' + text);
+    };
+};
+
+
+document.getElementById("canvas").addEventListener("click", async function () {
+    document.getElementById("canvas").focus();
+});

--- a/Browser_IDE/loadsplashkit.js
+++ b/Browser_IDE/loadsplashkit.js
@@ -4,7 +4,12 @@ let statusElement = document.getElementById('status');
 let progressElement = document.getElementById('progress');
 let spinnerElement = document.getElementById('spinner');
 
+let moduleEvents = new EventTarget();
+
 var Module = {
+    onRuntimeInitialized: (function() {
+        moduleEvents.dispatchEvent(new Event("onRuntimeInitialized"));
+    }),
     print: (function() {
         let element = document.getElementById('output');
         if (element) element.value = ''; // clear browser cache

--- a/Browser_IDE/package-lock.json
+++ b/Browser_IDE/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^1.20.2",
+        "codemirror": "^5.65.16",
         "compilex": "^0.7.4",
         "express": "^4.18.2",
         "nodemon": "^3.0.1"
@@ -150,6 +151,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
     },
     "node_modules/colors": {
       "version": "0.6.2",
@@ -1113,6 +1119,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "codemirror": {
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
     },
     "colors": {
       "version": "0.6.2",

--- a/Browser_IDE/package.json
+++ b/Browser_IDE/package.json
@@ -10,10 +10,10 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
+    "codemirror": "^5.65.16",
     "compilex": "^0.7.4",
     "express": "^4.18.2",
     "nodemon": "^3.0.1"
   },
-  "devDependencies": {},
   "description": ""
 }


### PR DESCRIPTION
# Description

Some commits that load SplashKit's Emscripten port during page loading, along with an event handler
so that other scripts can be called back once it finishes loading. There are also some small other fixes to the repo
so that it runs.

Fixes NA

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

It has been tested within the browser's console, by loading the module and executing the following commands:
```
SK = new Module.SplashKitJavascript()
SK.create_window("Test",640,360);
```


## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request