### PR TITLE
Add Splashkit Javascript execution to the IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+temp/

--- a/Browser_IDE/Api.js
+++ b/Browser_IDE/Api.js
@@ -2,12 +2,12 @@ const express = require("express")
 const app = express()
 const bodyP = require("body-parser")
 const compiler = require("compilex")
+var path = require('path');
 const options = { stats: true }
 compiler.init(options)
 app.use(bodyP.json())
 
-// change this to the path of your codemirror folder before running the server
-app.use("/codemirror-5.65.15", express.static("E:\Code\web-editor\CodeEditor\codemirror-5.65.15"))
+app.use("/codemirror-5.65.15", express.static(path.join(__dirname,"node_modules/codemirror")))
 
 app.use(function (req, res, next) {
     res.header("Access-Control-Allow-Origin", "*");
@@ -19,13 +19,14 @@ app.use(function (req, res, next) {
     next();
   });
 
+app.use(express.static(path.join(__dirname,"")));
+
 app.get("/", function (req, res) {
     compiler.flush(function () {
         console.log("deleted")
     })
 
-    // change this to the path of your index.html file before running the server
-    res.sendFile("E:\Code\web-editor\CodeEditor\index.html")
+    res.sendFile("index.html", { root: __dirname })
 })
 app.post("/compile", function (req, res) {
     var code = req.body.code

--- a/Browser_IDE/fsevents.js
+++ b/Browser_IDE/fsevents.js
@@ -1,0 +1,125 @@
+"use strict";
+
+let FSEvents = new EventTarget();
+
+// File System Delegate Initialization
+moduleEvents.addEventListener("onRuntimeInitialized", function() {
+    // Attach to file system callbacks
+    FS.trackingDelegate['willMovePath'] = function(oldpath, newpath) {
+        let ev = new Event("willMovePath");
+        ev.oldpath = oldpath;
+        ev.newpath = newpath;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onMovePath'] = function(oldpath, newpath) {
+        let ev = new Event("onMovePath");
+        ev.oldpath = oldpath;
+        ev.newpath = newpath;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['willDeletePath'] = function(path) {
+        let ev = new Event("willDeletePath");
+        ev.path = path;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onDeletePath'] = function(path) {
+        let ev = new Event("onDeletePath");
+        ev.path = path;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onOpenFile'] = function(path, flags) {
+        let ev = new Event("onOpenFile");
+        ev.path = path;
+        ev.flags = flags;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onReadFile'] = function(path, bytesRead) {
+        let ev = new Event("onReadFile");
+        ev.path = path;
+        ev.bytesRead = bytesRead;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onWriteToFile'] = function(path, bytesWritten) {
+        let ev = new Event("onWriteToFile");
+        ev.path = path;
+        ev.bytesWritten = bytesWritten;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onSeekFile'] = function(path, position, whence) {
+        let ev = new Event("onSeekFile");
+        ev.path = path;
+        ev.position = position;
+        ev.whence = whence;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onCloseFile'] = function(path) {
+        let ev = new Event("onCloseFile");
+        ev.path = path;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onMakeDirectory'] = function(path, mode) {
+        let ev = new Event("onMakeDirectory");
+        ev.path = path;
+        ev.mode = mode;
+        FSEvents.dispatchEvent(ev);
+    };
+    FS.trackingDelegate['onMakeSymlink'] = function(oldpath, newpath) {
+        let ev = new Event("onMakeSymlink");
+        ev.oldpath = oldpath;
+        ev.newpath = newpath;
+        FSEvents.dispatchEvent(ev);
+    };
+});
+
+function TestFSEvents()
+{
+    FSEvents.addEventListener('willMovePath', function(e) {
+        console.log('About to move "' + e.oldpath + '" to "' + e.newpath + '"');
+    });
+    FSEvents.addEventListener('onMovePath', function(e) {
+        console.log('Moved "' + e.oldpath + '" to "' + e.newpath + '"');
+    });
+    FSEvents.addEventListener('willDeletePath', function(e) {
+        console.log('About to delete "' + e.path + '"');
+    });
+    FSEvents.addEventListener('onDeletePath', function(e) {
+        console.log('Deleted "' + e.path + '"');
+    });
+    FSEvents.addEventListener('onOpenFile', function(e) {
+        console.log('Opened "' + e.path + '" with flags ' + e.flags);
+    });
+    FSEvents.addEventListener('onReadFile', function(e) {
+        console.log('Read ' + e.bytesRead + ' bytes from "' + e.path + '"');
+    });
+    FSEvents.addEventListener('onWriteToFile', function(e) {
+        console.log('Wrote to file "' + e.path + '" with ' + e.bytesWritten + ' bytes written');
+    });
+    FSEvents.addEventListener('onSeekFile', function(e) {
+        console.log('Seek on "' + e.path + '" with position ' + e.position + ' and whence ' + e.whence);
+    });
+    FSEvents.addEventListener('onCloseFile', function(e) {
+        console.log('Closed ' + e.path);
+    });
+    FSEvents.addEventListener('onMakeDirectory', function(e) {
+        console.log('Created directory ' + e.path + ' with mode ' + e.mode);
+    });
+    FSEvents.addEventListener('onMakeSymlink', function(e) {
+        console.log('Created symlink from ' + e.oldpath + ' to ' + e.newpath);
+    });
+
+    FS.mkdir("/testDir");
+    FS.rename("/testDir","/testDirRnm");
+    FS.rmdir("/testDirRnm");
+    FS.writeFile('/testFile.txt', 'Hello World!');
+    FS.readFile('/testFile.txt');
+    FS.symlink("/testFile.txt", "/testFileRenamed.txt");
+
+    let stream = FS.open("/testFileRenamed.txt", "r");
+    FS.llseek(stream, 6, 0);
+    let buf = new Uint8Array(5);
+    FS.read(stream, buf, 0, 5, 0);
+    FS.close(stream);
+
+    FS.unlink("/testFileRenamed.txt");
+    FS.unlink("/testFile.txt");
+}

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -83,6 +83,7 @@ write_line("Test!");
 
 <script src="loadsplashkit.js"></script>
 <script src="splashkitapi.js"></script>
+<script src="fsevents.js"></script>
 <script src="script.js"></script>
 <script src="splashkit/SplashKitBackendWASM.js"></script>
 </html>

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -1,4 +1,5 @@
 <!-- Sherap's work starts here -->
+<!-- Heavily modified by Sean, not much remaining of the original -->
 <!DOCTYPE html>
 <html lang="en">
 
@@ -31,6 +32,9 @@
         <div class="flex-row d-flex m-3 flex-grow-1">
             <div class="d-flex flex-column" style="max-width:40em;">
                 <div class="d-flex justify-content-between mb-2 bg-dark rounded p-2">
+                    <div class="flex-column col-12 w-25">
+                        <h3 style="color:white;"> Initialization </h3>
+                    </div>
                     <div>
                         <button type="button" id="runInit" class="btn btn-success"><i class="bi bi-play-fill"></i></button>
                     </div>
@@ -40,7 +44,17 @@
 open_window("test!",1280,720);
 clear_screen(rgba_color_from_double(1.0,1.0,1.0,0));
 refresh_screen();
-
+</textarea>
+                </div>
+                <div class="d-flex justify-content-between mb-2 bg-dark rounded p-2 ">
+                    <div class="flex-column col-12 w-25"><h3 style="color:white;"> Main Loop </h3></div>
+                    <div>
+                        <button type="button" id="runMainLoop" class="btn btn-success"><i class="bi bi-play-fill"></i></button>
+                        <button type="button" id="pauseMainLoop" class="btn btn-success"><i class="bi bi-pause-fill"></i></button>
+                    </div>
+                </div>
+                <div class="d-flex mb-2 bg-dark rounded p-2 flex-grow-1 flex-column">
+                <textarea type="text" id="editorMainLoop" class="form-control flex-grow-1" aria-label="editorMainLoop" style="height:100%;">
 clear_screen(rgba_color_from_double(1,1,1,1));
 fill_ellipse(rgba_color_from_double(0,1,0,1), 0, 400, 800, 400);
 fill_rectangle(rgba_color_from_double(0.4,0.4,0.4,1), 300, 300, 200, 200);
@@ -72,4 +86,5 @@ write_line("Test!");
 <script src="script.js"></script>
 <script src="splashkit/SplashKitBackendWASM.js"></script>
 </html>
+<!-- Sean's work ends here -->
 <!-- Sherap's work ends here -->

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -18,30 +18,38 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
         crossorigin="anonymous"></script>
-    <script src="codemirror-5.65.15/mode/python/python.js"></script>
-    <script src="codemirror-5.65.15/mode/clike/clike.js"></script>
+    <script src="codemirror-5.65.15/mode/javascript/javascript.js"></script>
     <script src="codemirror-5.65.15/addon/edit/closebrackets.js"></script>
 </head>
 
-<body>
-    <div class="row m-3">
-        <div class="col">
-            <div class="d-flex justify-content-between mb-2 bg-dark rounded p-2">
-                <div class="col-12 w-25">
-                    <label class="visually-hidden" for="inlineFormSelectPref">Preference</label>
-                    <select class="form-select" id="inlineFormSelectPref">
-                        <option value="Python">Python</option>
-                        <option value="Java">Java</option>
-                        <option value="Cpp">Cpp</option>
-                    </select>
+<body class="bg-dark" style="position:relative;width:100%;height:100vh;margin:0;padding:0;display:flex;">
+    <div class="flex-column d-flex flex-grow-1">
+        <div class="flex-row d-flex p-3 justify-content-center" style="color:white;background-color:#3F51B5; vertical-align:middle;align-items:center;">
+            <img src="https://splashkit.io/images/skbox-5d36169d.svg" style="width:5em;"/>
+            <h1>SplashKit Online IDE</h1>
+        </div>
+        <div class="flex-row d-flex m-3 flex-grow-1">
+            <div class="d-flex flex-column" style="max-width:40em;">
+                <div class="d-flex justify-content-between mb-2 bg-dark rounded p-2">
+                    <div>
+                        <button type="button" id="runInit" class="btn btn-success"><i class="bi bi-play-fill"></i></button>
+                    </div>
                 </div>
-                <div>
-                    <button type="button" id="run" class="btn btn-success"><i class="bi bi-play-fill"></i></button>
+                <div class="d-flex mb-2 bg-dark rounded p-2 flex-shrink-2 flex-column" style="height:20%;">
+                    <textarea type="text" id="editorInit" class="form-control flex-shrink-1" aria-label="editor" style="height:100%;">
+open_window("test!",1280,720);
+clear_screen(rgba_color_from_double(1.0,1.0,1.0,0));
+refresh_screen();
+
+clear_screen(rgba_color_from_double(1,1,1,1));
+fill_ellipse(rgba_color_from_double(0,1,0,1), 0, 400, 800, 400);
+fill_rectangle(rgba_color_from_double(0.4,0.4,0.4,1), 300, 300, 200, 200);
+fill_triangle(rgba_color_from_double(1,0,0,1), 250, 300, 400, 150, 550, 300);
+refresh_screen();
+write_line("Test!");
+</textarea>
                 </div>
             </div>
-            <textarea type="text" id="editor" class="form-control" aria-label="First name"></textarea>
-        </div>
-        <div class="col d-flex flex-column rounded bg-dark px-4">
             <div class="col d-flex flex-column rounded bg-dark px-4 justify-content-center flex-grow-1" >
                 <figure style="" id="spinner"><div></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
                 <div id="status">Downloading...</div>
@@ -60,6 +68,7 @@
 </body>
 
 <script src="loadsplashkit.js"></script>
+<script src="splashkitapi.js"></script>
 <script src="script.js"></script>
 <script src="splashkit/SplashKitBackendWASM.js"></script>
 </html>

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -42,19 +42,25 @@
             <textarea type="text" id="editor" class="form-control" aria-label="First name"></textarea>
         </div>
         <div class="col d-flex flex-column rounded bg-dark px-4">
-            <div class="h-50">
-                <label for="Input" class="text-light mt-4 mb-2">Input</label>
-                <textarea type="text" id="input" class="form-control h-75" aria-label="Last name"></textarea>
-            </div>
-            <div class="h-50">
-                <label for="Output" class="text-light mb-2">Output</label>
-                <textarea type="text" id="output" class="form-control h-75" aria-label="Last name"></textarea>
+            <div class="col d-flex flex-column rounded bg-dark px-4 justify-content-center flex-grow-1" >
+                <figure style="" id="spinner"><div></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
+                <div id="status">Downloading...</div>
+                <div>
+                  <progress value="0" max="100" id="progress" hidden=1></progress>
+                </div>
+                <div class="row m-3">
+                  <canvas id="canvas" style="vertical-align:center; max-width: 100%; width:inherit;" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+                </div>
+                <div class="row m-3">
+                    <textarea id="output"  readonly style="height:16em; background-color:#282a36; color:#f8f8f2; border:none;"></textarea>
+                </div>
             </div>
         </div>
     </div>
 </body>
 
+<script src="loadsplashkit.js"></script>
 <script src="script.js"></script>
-
+<script src="splashkit/SplashKitBackendWASM.js"></script>
 </html>
 <!-- Sherap's work ends here -->

--- a/Browser_IDE/loadsplashkit.js
+++ b/Browser_IDE/loadsplashkit.js
@@ -1,0 +1,79 @@
+"use strict";
+
+let statusElement = document.getElementById('status');
+let progressElement = document.getElementById('progress');
+let spinnerElement = document.getElementById('spinner');
+
+var Module = {
+    print: (function() {
+        let element = document.getElementById('output');
+        if (element) element.value = ''; // clear browser cache
+        return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+                element.value += text + "\n";
+                element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+        };
+    })(),
+    canvas: (() => {
+        let canvas = document.getElementById('canvas');
+
+        // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+        // application robust, you may want to override this behavior before shipping!
+        // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+        canvas.addEventListener("webglcontextlost", (e) => { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+        return canvas;
+    })(),
+    setStatus: (text) => {
+        if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+        if (text === Module.setStatus.last.text) return;
+        let m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+        let now = Date.now();
+        if (m && now - Module.setStatus.last.time < 30) return; // if this is a progress update, skip it if too soon
+        Module.setStatus.last.time = now;
+        Module.setStatus.last.text = text;
+        if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+        } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.hidden = true;
+        }
+        statusElement.innerHTML = text;
+    },
+    totalDependencies: 0,
+    monitorRunDependencies: (left) => {
+        this.totalDependencies = Math.max(this.totalDependencies, left);
+        Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+    },
+    preRun: (function() {
+        ENV.SDL_EMSCRIPTEN_KEYBOARD_ELEMENT = "canvas";
+    }),
+};
+
+Module.setStatus('Downloading...');
+window.onerror = () => {
+    Module.setStatus('Exception thrown, see JavaScript console');
+    spinnerElement.style.display = 'none';
+    Module.setStatus = (text) => {
+        if (text) console.error('[post-exception status] ' + text);
+    };
+};
+
+
+document.getElementById("canvas").addEventListener("click", async function () {
+    document.getElementById("canvas").focus();
+});

--- a/Browser_IDE/loadsplashkit.js
+++ b/Browser_IDE/loadsplashkit.js
@@ -4,7 +4,12 @@ let statusElement = document.getElementById('status');
 let progressElement = document.getElementById('progress');
 let spinnerElement = document.getElementById('spinner');
 
+let moduleEvents = new EventTarget();
+
 var Module = {
+    onRuntimeInitialized: (function() {
+        moduleEvents.dispatchEvent(new Event("onRuntimeInitialized"));
+    }),
     print: (function() {
         let element = document.getElementById('output');
         if (element) element.value = ''; // clear browser cache

--- a/Browser_IDE/package-lock.json
+++ b/Browser_IDE/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^1.20.2",
+        "codemirror": "^5.65.16",
         "compilex": "^0.7.4",
         "express": "^4.18.2",
         "nodemon": "^3.0.1"
@@ -150,6 +151,11 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/codemirror": {
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
     },
     "node_modules/colors": {
       "version": "0.6.2",
@@ -1113,6 +1119,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "codemirror": {
+      "version": "5.65.16",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+      "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
     },
     "colors": {
       "version": "0.6.2",

--- a/Browser_IDE/package.json
+++ b/Browser_IDE/package.json
@@ -10,10 +10,10 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.20.2",
+    "codemirror": "^5.65.16",
     "compilex": "^0.7.4",
     "express": "^4.18.2",
     "nodemon": "^3.0.1"
   },
-  "devDependencies": {},
   "description": ""
 }

--- a/Browser_IDE/script.js
+++ b/Browser_IDE/script.js
@@ -8,15 +8,58 @@ let editorInit = CodeMirror.fromTextArea(document.getElementById("editorInit"), 
 })
 editorInit.display.wrapper.classList.add("flex-grow-1");
 
+let editorMainLoop = CodeMirror.fromTextArea(document.getElementById("editorMainLoop"), {
+    mode: "text/javascript",
+    theme: "dracula",
+    lineNumbers: true,
+    autoCloseBrackets: true,
+})
+editorMainLoop.display.wrapper.classList.add("flex-grow-1");
+
 let width = window.innerWidth
 let runInitButton = document.getElementById("runInit")
+let runMainLoopButton = document.getElementById("runMainLoop")
+let pauseMainLoopButton = document.getElementById("pauseMainLoop")
 
 // Code Running
+let runMainLoopGo = false;
+let mainLoopCode = "";
+let mainLoop = function(){
+    eval(mainLoopCode);
+    if (runMainLoopGo)
+        window.requestAnimationFrame(mainLoop);
+}
+
+
 function runInitialization(){
     eval(editorInit.getValue());
 }
 
+function runMainLoop(){
+    runMainLoopGo = true;
+    mainLoopCode = editorMainLoop.getValue();
+    window.requestAnimationFrame(mainLoop);
+}
+
+function stopMainLoop(){
+    runMainLoopGo = false;
+}
+
+
 // Setup code editor buttons
+pauseMainLoopButton.disabled = true;
+
 runInitButton.addEventListener("click", async function () {
     runInitialization();
+});
+
+runMainLoopButton.addEventListener("click", async function () {
+    runMainLoop();
+    pauseMainLoopButton.disabled = false;
+});
+
+pauseMainLoopButton.addEventListener("click", async function () {
+    stopMainLoop();
+    runMainLoopButton.disabled = false;
+    pauseMainLoopButton.disabled = true;
 });

--- a/Browser_IDE/script.js
+++ b/Browser_IDE/script.js
@@ -1,50 +1,22 @@
-var editor = CodeMirror.fromTextArea(document.getElementById("editor"), {
-    mode: "text/x-c++src",
+"use strict";
+
+let editorInit = CodeMirror.fromTextArea(document.getElementById("editorInit"), {
+    mode: "text/javascript",
     theme: "dracula",
     lineNumbers: true,
     autoCloseBrackets: true,
 })
+editorInit.display.wrapper.classList.add("flex-grow-1");
 
-var width = window.innerWidth
-var input = document.getElementById("input")
-var output = document.getElementById("output")
-var run = document.getElementById("run")
-editor.setSize(0.7 * width, "500")
+let width = window.innerWidth
+let runInitButton = document.getElementById("runInit")
 
-var option = document.getElementById("inlineFormSelectPref")
+// Code Running
+function runInitialization(){
+    eval(editorInit.getValue());
+}
 
-option.addEventListener("change", function () {
-    if (option.value == "Java") {
-        editor.setOption("mode", "text/x-java")
-    }
-    else if (option.value == "Cpp") {
-        editor.setOption("mode", "text/x-c++src")
-    }
-    else {
-        editor.setOption("mode", "text/x-python")
-    }
-})
-
-// Sherap's work starts here
-var code;
-
-run.addEventListener("click", async function () {
-    code = {
-        code: editor.getValue(),
-        input: input.value,
-        lang: option.value
-    }
-    console.log(code)
-    var oData = await fetch("http://localhost:8000/compile", {
-        method: "POST",
-        headers: {
-            "Content-Type": "application/json"
-        },
-        body: JSON.stringify(code)
-    })
-    var d = await oData.json()
-    output.value = d.output
-    console.log(d.output);
-})
-// Sherap's work ends here
-
+// Setup code editor buttons
+runInitButton.addEventListener("click", async function () {
+    runInitialization();
+});

--- a/Browser_IDE/script.js
+++ b/Browser_IDE/script.js
@@ -45,15 +45,48 @@ function stopMainLoop(){
     runMainLoopGo = false;
 }
 
+let initCodePath = "/code/codeblock_init.js"
+let mainLoopCodePath = "/code/codeblock_mainloop.js"
+function makeCodeFolder(){
+    try{
+        FS.mkdir("/code");
+    }
+    catch {}
+}
+function saveInitialization(){
+    makeCodeFolder();
+    FS.writeFile(initCodePath, editorInit.getValue());
+}
+function saveMainLoop()
+{
+    makeCodeFolder();
+    FS.writeFile(mainLoopCodePath, editorMainLoop.getValue());
+}
+
+function loadInitialization(){
+    editorInit.setValue(FS.readFile(initCodePath, {encoding: 'utf8'}));
+}
+function loadMainLoop()
+{
+    editorMainLoop.setValue(FS.readFile(mainLoopCodePath, {encoding: 'utf8'}));
+}
+FSEvents.addEventListener('onWriteToFile', function(e) {
+    if (e.path == initCodePath)
+        loadInitialization();
+    else if (e.path == mainLoopCodePath)
+        loadMainLoop();
+});
 
 // Setup code editor buttons
 pauseMainLoopButton.disabled = true;
 
 runInitButton.addEventListener("click", async function () {
+    saveInitialization();
     runInitialization();
 });
 
 runMainLoopButton.addEventListener("click", async function () {
+    saveMainLoop();
     runMainLoop();
     pauseMainLoopButton.disabled = false;
 });

--- a/Browser_IDE/splashkitapi.js
+++ b/Browser_IDE/splashkitapi.js
@@ -1,0 +1,46 @@
+// TODO: This should be automated
+let SK;
+let clear_screen;
+let open_window;
+let refresh_screen;
+let rgba_color_from_double;
+let fill_ellipse;
+let fill_rectangle;
+let fill_triangle;
+let process_events;
+let any_key_pressed;
+let key_down;
+let write_line;
+let mouse_position;
+let QUOTE_ENTER;
+let W_KEY;
+let A_KEY;
+let S_KEY;
+let D_KEY;
+let LEFT_BUTTON;
+let mouse_clicked;
+let mouse_down;
+
+moduleEvents.addEventListener("onRuntimeInitialized", function() {
+    SK = new Module.SplashKitJavascript();
+    clear_screen = SK.clear_screen;
+    open_window = SK.open_window;
+    refresh_screen = SK.refresh_screen;
+    rgba_color_from_double = SK.rgba_color_from_double;
+    fill_ellipse = SK.fill_ellipse;
+    fill_rectangle = SK.fill_rectangle;
+    fill_triangle = SK.fill_triangle;
+    process_events = SK.process_events;
+    any_key_pressed = SK.any_key_pressed;
+    key_down = SK.key_down;
+    write_line = SK.write_line;
+    mouse_position = SK.mouse_position;
+    QUOTE_ENTER = Module.QUOTE_ENTER;
+    W_KEY = Module.W_KEY;
+    A_KEY = Module.A_KEY;
+    S_KEY = Module.S_KEY;
+    D_KEY = Module.D_KEY;
+    LEFT_BUTTON = Module.LEFT_BUTTON;
+    mouse_clicked = SK.mouse_clicked;
+    mouse_down = SK.mouse_down;
+});


### PR DESCRIPTION
# Description

Extends the code IDE to support executing Splashkit functions through Javascript. Removes existing code compilation code and interface.

Depends on #10 

Fixes NA

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

# How Has This Been Tested?

Code has been executed and tested within the IDE.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request