### PR TITLE
Add Project Upload/Download Support

### DIFF
--- a/Browser_IDE/Api.js
+++ b/Browser_IDE/Api.js
@@ -8,6 +8,7 @@ compiler.init(options)
 app.use(bodyP.json())
 
 app.use("/codemirror-5.65.15", express.static(path.join(__dirname,"node_modules/codemirror")))
+app.use("/jszip", express.static(path.join(__dirname,"node_modules/jszip/dist/")))
 
 app.use(function (req, res, next) {
     res.header("Access-Control-Allow-Origin", "*");

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -117,7 +117,7 @@ function isViewablePath(path){
 
 // File System Upload/Download Functions
 let reader = null;
-function uploadFile(){
+function uploadFileFromInput(){
     reader= new FileReader();
     let files = document.getElementById('fileuploader').files;
     let file = files[0]; // maybe should handle multiple at once?
@@ -132,23 +132,9 @@ function uploadFile(){
 }
 
 // Thanks Lucas Vinicius Hartmann! - https://stackoverflow.com/a/54468787
-// for viewFile and downloadFile - somewhat modified
-function viewFile(filename, mime) {
+// for FSviewFile and downloadFile - somewhat modified
+function downloadFileGeneric(content, filename, mime) {
     mime = mime || "application/octet-stream";
-
-    let content = Module.FS.readFile(filename);
-
-    let url = URL.createObjectURL(new Blob([content], {type: mime}));
-
-    window.open(url+"#"+filename);
-    setTimeout(() => {
-        URL.revokeObjectURL(url);
-    }, 2000);
-}
-function downloadFile(filename, mime) {
-    mime = mime || "application/octet-stream";
-
-    let content = Module.FS.readFile(filename);
 
     let a = document.createElement('a');
     a.download = filename;
@@ -163,6 +149,23 @@ function downloadFile(filename, mime) {
         document.body.removeChild(a);
         URL.revokeObjectURL(a.href);
     }, 2000);
+}
+function FSviewFile(filename, mime) {
+    mime = mime || "application/octet-stream";
+
+    let content = Module.FS.readFile(filename);
+
+    let url = URL.createObjectURL(new Blob([content], {type: mime}));
+
+    window.open(url+"#"+filename);
+    setTimeout(() => {
+        URL.revokeObjectURL(url);
+    }, 2000);
+}
+function FSdownloadFile(filename, mime) {
+    let content = Module.FS.readFile(filename);
+
+    downloadFileGeneric(content, filename, mime);
 }
 
 
@@ -281,7 +284,7 @@ function makeFileNode(label){
     });
     file_node_label.addEventListener("dblclick", async function (e) {
         e.stopPropagation();
-        viewFile(getFullPath(file_node_label),"text/plain");
+        FSviewFile(getFullPath(file_node_label),"text/plain");
     });
 
     initFileNodeCallbacks(file_node_label);

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -1,12 +1,237 @@
 "use strict";
 
-function nodeExists(path)
-{
+// ------- Utility Functions --------
+// function 'contains' from Aleksandr Makov - https://stackoverflow.com/a/47485168
+// How does this work??
+function contains(parent, child) {
+  return parent !== child && parent.contains(child);
+}
+// Node Utility Functions
+function isNode(node){
+    return node.classList.contains("node");
+}
+function isDirectory(node){
+    return node.classList.contains("directory");
+}
+function getParentDirectory(node){
+    if (node.dataset.label=="" || node.dataset.label==undefined)
+        return null;
+    return node.parentElement.parentElement;
+}
+function getDirectoryContents(node){
+    return node.children[1];
+}
+function getFilename(node){
+    return node.dataset.label;
+}
+function getFullDirectoryPath(node){
+    let ret = "";
+    let dir = getParentDirectory(node);
+    while(dir!=null){
+        ret = getFilename(dir)+"/"+ret;
+        dir = getParentDirectory(dir);
+    }
+    return ret;
+}
+function getFullPath(node){
+    return getFullDirectoryPath(node)+getFilename(node);
+}
+function getChildNodeWithFilename(root, name){
+    for(let child of getDirectoryContents(root).children){
+        if (getFilename(child)==name)
+            return child;
+    }
+    return null;
+}
+function getNodeFromPath(path){
+    let dir = document.getElementById("fileView");
+
+    for (let part of splitPath(path)){
+        dir = getChildNodeWithFilename(dir, part);
+        if (dir==null)
+            return null;
+    }
+    return dir;
+}
+
+// String Path Utility Functions
+function pathDirName(path){
+    return path.substring(0, path.lastIndexOf("/"));
+}
+function pathFileName(path){
+    return path.substring(path.lastIndexOf("/")+1);
+}
+function pathFileExtension(path){
+    return path.substring(path.lastIndexOf(".")+1);
+}
+function splitPath(path){
+    return path.split("/").slice(1);
+}
+
+// TreeView Utility Functions
+function moveNodeToPathUI(node, newPath, index){
+    if (!isViewablePath(newPath))return;
+    let new_dir_node = getNodeFromPath(pathDirName(newPath));
+
+    if (index == -1 || index >= getDirectoryContents(new_dir_node).children.length)
+        getDirectoryContents(new_dir_node).appendChild(node);
+    else
+        getDirectoryContents(new_dir_node).insertBefore(node, getDirectoryContents(new_dir_node).children[index]);
+}
+
+// File System Utility Functions
+function FSFileExists(path){
     try{FS.lookupPath(path, { follow: false }).node; return true;}
     catch(e) {return false;}
 }
+function scanFilesystem(path){
+    let dirs_files = FS.readdir(path).slice(2);
+
+    let nodes = []
+    for(let thing of dirs_files){
+        if (thing == "fd")
+            continue;
+        let abs_path = path+""+thing;
+
+        let info = FS.stat(abs_path);
+        let node = new Map();
+        node.set("label", thing);
+        node.set("path", abs_path);
+        node.set("children", null);
+        if (FS.isDir(info.mode)){
+            node.set("children", scanFilesystem(abs_path+"/"));
+        }
+        nodes.push(node);
+    }
+    return nodes;
+}
+function isViewablePath(path){
+    if (path.startsWith("/tmp"))return false;
+    if (path.startsWith("/home"))return false;
+    if (path.startsWith("/dev"))return false;
+    if (path.startsWith("/proc"))return false;
+    return true;
+}
 
 
+// File System UI Node Creation Functions
+function initFileNodeCallbacks(_node)
+{
+    let node = _node;
+    node.addEventListener("mousedown", async function (e) {
+        e.stopPropagation();
+        e.preventDefault();
+
+        isDragPotential = true;
+
+        mouseStart[0] = e.clientX;
+        mouseStart[1] = e.clientY;
+
+        let offsets = node.getBoundingClientRect();
+        dragOffset[0] = offsets.left;
+        dragOffset[1] = offsets.top;
+
+        draggedNode = node;
+    });
+}
+
+function makeDirectoryNode(label){
+    let dir_node = document.createElement("div");
+    dir_node.classList.add("node");
+    dir_node.classList.add("directory");
+    dir_node.dataset.label = label;
+
+    let dir_node_label = document.createElement("div");
+    dir_node_label.classList.add("node-label", "bi-folder2-open");
+
+    let dir_node_label_text = document.createTextNode(label);
+
+    let dir_node_contents = document.createElement("div");
+    dir_node_contents.classList.add("directory-contents", "open-directory");
+
+
+    dir_node_label.appendChild(dir_node_label_text);
+    dir_node.appendChild(dir_node_label);
+    dir_node.appendChild(dir_node_contents);
+
+    // Handle showing/hiding the folder's contents
+    // Uses a combination of CSS transitions + some Javascript
+    // hacks to make it function correctly.
+    dir_node.addEventListener("click", async function (e) {
+        let isOpen = dir_node_contents.classList.contains("open-directory");
+        let newState = !isOpen;
+        if (newState == false){
+            dir_node_contents.classList.remove("open-directory");
+            dir_node_contents.classList.add("closed-directory");
+            dir_node_contents.style.maxHeight = dir_node.children[1].scrollHeight+"px";
+            window.getComputedStyle(dir_node.children[1]).maxHeight; // Hack to force it to immediately update its height
+            dir_node_contents.style.maxHeight = "0px"; // This then becomes the target height to transition to
+            dir_node_label.classList.remove("bi-folder2-open");
+            dir_node_label.classList.add("bi-folder2");
+        }
+        else{
+            dir_node_contents.classList.add("open-directory");
+            dir_node_contents.classList.remove("closed-directory");
+            dir_node_contents.style.maxHeight = dir_node.children[1].scrollHeight+"px";
+            dir_node_label.classList.add("bi-folder2-open");
+            dir_node_label.classList.remove("bi-folder2");
+            setTimeout(function(){
+                isOpen = dir_node.children[1].classList.contains("open-directory");
+                if (isOpen)
+                    dir_node.children[1].style.maxHeight = 'initial';
+            }, 320);
+        }
+        e.stopPropagation();
+    });
+
+    initFileNodeCallbacks(dir_node);
+    return dir_node;
+}
+
+function makeFileNode(label){
+    let extensionLookup = {"json":"json","ogg":"sound", "mp3":"sound", "wav":"sound", "m4a":"sound", "png":"image", "jpg":"image", "bmp":"image"};
+    let iconLookup = {"sound":"bi-file-music", "image":"bi-file-image", "json":"bi-filetype-json", "unknown":"bi-file"};
+
+    let file_node_label = document.createElement("div");
+    file_node_label.classList.add("node", "file", "node-label");
+    file_node_label.dataset.label = label;
+
+    let fileType = extensionLookup[pathFileExtension(label)];
+    if (fileType==null||fileType==undefined)
+        fileType = "unknown";
+    file_node_label.classList.add(iconLookup[fileType]);
+
+    let file_node_label_text = document.createTextNode(label);
+
+    file_node_label.appendChild(file_node_label_text);
+
+    file_node_label.addEventListener("click", async function (e) {
+        e.stopPropagation();
+    });
+
+    initFileNodeCallbacks(file_node_label);
+    return file_node_label;
+}
+
+function populatefileView(files, root){
+    for (let file of files){
+        if (!isViewablePath(file.get("path")))continue;
+        if (file.get("children")!=null)
+        {
+            let dir_node = makeDirectoryNode(file.get("label"));
+            root.appendChild(dir_node);
+            populatefileView(file.get("children"), dir_node.children[1]);
+        }
+        else
+        {
+            let file_node_label = makeFileNode(file.get("label"));
+            root.appendChild(file_node_label);
+        }
+    }
+}
+
+
+// Drag&Drop Handling Functions, Variables and Events
 let isDragPotential = false;
 let mouseStart = [0,0];
 let dragOffset = [0,0];
@@ -14,136 +239,153 @@ let draggedNode = null;
 let draggedClone = null;
 let isDragging = false;
 let dragDist = 4*4;
-let currentTarget = null;
+
 let insertionPoint = document.createElement("div");
 insertionPoint.classList.add("insertion-point-display");
 
-for (let node of document.getElementsByClassName("directory"))
-{
-    node.addEventListener("click", async function (e) {
-        //alert("clicked" + node.text);
-        let isOpen = node.children[1].classList.contains("open-directory");
-        let newState = !isOpen;
-        if (newState == false)
-        {
-            node.children[1].classList.remove("open-directory");
-            node.children[1].classList.add("closed-directory");
-            node.children[1].style.maxHeight = node.children[1].scrollHeight+"px";
-            window.getComputedStyle(node.children[1]).maxHeight;
-            node.children[1].style.maxHeight = "0px";
-            node.children[0].classList.remove("bi-folder2-open");
-            node.children[0].classList.add("bi-folder2");
-        }
-        else
-        {
-            node.children[1].classList.add("open-directory");
-            node.children[1].classList.remove("closed-directory");
-            node.children[1].style.maxHeight = node.children[1].scrollHeight+"px";
-            node.children[0].classList.add("bi-folder2-open");
-            node.children[0].classList.remove("bi-folder2");
-            setTimeout(function(){
-                isOpen = node.children[1].classList.contains("open-directory");
-                if (isOpen)
-                    node.children[1].style.maxHeight = 'initial';
-            }, 320);
-        }
-        e.stopPropagation();
-    });
-}
-for (let node of document.getElementsByClassName("file"))
-{
-    node.addEventListener("click", async function (e) {
-        e.stopPropagation();
-    });
-}
-for (let node of document.getElementsByClassName("node"))
-{
-    node.addEventListener("mousedown", async function (e) {
-        e.stopPropagation();
-        e.preventDefault();
-        isDragPotential = true;
-        mouseStart[0] = e.clientX;// + node.offsetLeft;
-        mouseStart[1] = e.clientY;// + node.offsetTop;
-        let offsets = node.getBoundingClientRect();
-        dragOffset[0] = offsets.left;//node.offsetLeft;
-        dragOffset[1] = offsets.top;//node.offsetTop;
-        draggedNode = node;
-    });
-}
-
-// How does this work??
-// function 'contains' from Aleksandr Makov - https://stackoverflow.com/a/47485168
-function contains(parent, child) {
-  return parent !== child && parent.contains(child);
-}
-
-function dropElementInNodeTree(cx,cy,elem)
-{
-    for(let under of document.elementsFromPoint(cx, cy))
-    {
-        if (under.classList.contains("node") && !contains(draggedNode, under) && !contains(draggedClone, under) && draggedClone != under)
-        {
-            let isDir = under.classList.contains("directory");
+function getNewPathInTree(cx,cy,elem){
+    for(let under of document.elementsFromPoint(cx, cy)){
+        if (isNode(under) && !contains(draggedNode, under) && !contains(draggedClone, under) && draggedClone != under){
+            let isDir = isDirectory(under);
             let label = under;
             if (isDir)
                 label = under.children[0];
             let offsets = label.getBoundingClientRect();
             let midpoint = offsets.top + offsets.height/2;
-            if (cy < midpoint || draggedNode == under)
-            {
-                under.parentElement.insertBefore(elem, under);
-            }
-            else
-            {
-                if (isDir)
-                    under.children[1].insertBefore(elem, under.children[1].children[0]);
-                else
-                    under.insertAdjacentElement("afterend", elem);
-            }
 
-            console.log(cy < midpoint);
+            let dropPos = "/";
+            let dropIndex = -1;
 
-            break;
+            if (cy < midpoint || draggedNode == under){
+                dropPos = getFullDirectoryPath(under)+getFilename(elem);
+                dropIndex = [].indexOf.call(under.parentNode.children, under);
+            }
+            else{
+                if (isDir){
+                    dropPos = getFullPath(under)+"/"+elem.dataset.label;
+                    dropIndex = 0;
+                }
+                else{
+                    dropPos = getFullDirectoryPath(under)+elem.dataset.label;
+                    dropIndex = [].indexOf.call(under.parentNode.children, under)+1;
+                }
+            }
+            return {path:dropPos, index:dropIndex};
         }
     }
+    return "/"+elem.dataset.label;
 }
+
+
 document.addEventListener("mousemove", function(e) {
-    if (isDragPotential || isDragging)
-    {
+    if (isDragPotential || isDragging){
         let cx = e.clientX;
-        let mx = mouseStart[0];//-dragOffset[0];
+        let mx = mouseStart[0];
         let cy = e.clientY;
-        let my = mouseStart[1];//-dragOffset[1];
-        if (!isDragging && (cx-mx)*(cx-mx) + (cy-my)*(cy-my) > dragDist)
-        {
+        let my = mouseStart[1];
+
+        // Check if should begin dragging
+        if (!isDragging && (cx-mx)*(cx-mx) + (cy-my)*(cy-my) > dragDist){
+            // If so, create a clone of the dragged object
             isDragging = true;
-            //draggedNode.style.position = 'relative';
             draggedClone = draggedNode.cloneNode(true);
             document.body.appendChild(draggedClone);
             draggedClone.classList.add('in-drag');
         }
-        if (isDragging)
-        {
-            //console.log("dragging"+(draggedNode.offsetLeft - parseInt(draggedNode.style.left, 10)));
-            draggedClone.style.left = (cx-mx+dragOffset[0])+"px";//+dragOffset[0]
-            draggedClone.style.top = (cy-my+dragOffset[1])+"px";//+dragOffset[1]
 
-            dropElementInNodeTree(cx, cy, insertionPoint);
+        // If dragging, update the position of the clone and move the
+        // insertionPoint line to the current insertion point.
+        if (isDragging){
+            draggedClone.style.left = (cx-mx+dragOffset[0])+"px";
+            draggedClone.style.top = (cy-my+dragOffset[1])+"px";
+
+            let newPath = getNewPathInTree(cx,cy,insertionPoint);
+            moveNodeToPathUI(insertionPoint, newPath.path, newPath.index);
         }
 
     }
 });
 
 document.addEventListener("mouseup", function(e) {
-    if (isDragging)
-    {
+    if (isDragging){
         let cx = e.clientX;
         let cy = e.clientY;
-        dropElementInNodeTree(cx, cy, draggedNode);
+
+        let newPath = getNewPathInTree(cx,cy,draggedNode);
+        let oldPath = getFullPath(draggedNode);
+
+        // Perform the rename, then reposition the draggedNode to the correct index
+        FS.rename(oldPath, newPath.path);
+        draggedNode.remove();
+        moveNodeToPathUI(draggedNode, newPath.path, newPath.index);
+
+        // Tidy up drag
         insertionPoint.remove();
         draggedClone.remove();
         draggedClone = null;
+        e.stopPropagation();
     }
     isDragPotential = false;
     isDragging = false;
+});
+
+
+// File System and File System View Initialization
+moduleEvents.addEventListener("onRuntimeInitialized", function() {
+
+    // Initialize file view with existing folders/files
+    populatefileView(scanFilesystem("/"), document.getElementById("fileView").children[1]);
+
+    // Attach to file system callbacks
+    FS.trackingDelegate['onMovePath'] = function(oldpath, newPath) {
+        moveNodeToPathUI(getNodeFromPath(oldpath), newPath, -1);
+    };
+    FS.trackingDelegate['onMakeDirectory'] = function(path, mode) {
+        if (!isViewablePath(path))return;
+
+        let new_dir_node = getNodeFromPath(pathDirName(path));
+
+        let dir_node = makeDirectoryNode(pathFileName(path), path);
+        getDirectoryContents(new_dir_node).appendChild(dir_node);
+
+    };
+    FS.trackingDelegate['onDeletePath'] = function(path) {
+        if (!isViewablePath(path))return;
+
+        let new_dir_node = getNodeFromPath(pathDirName(path));
+        new_dir_node.remove();
+    };
+    FS.trackingDelegate['onOpenFile'] = function(path, flags) {
+        if (!path.startsWith("/"))
+            path = "/"+path;
+        if (!isViewablePath(path))return;
+
+        let new_dir_node = getNodeFromPath(path);
+        if (new_dir_node!=null)
+            return;
+
+        new_dir_node = getNodeFromPath(pathDirName(path));
+        let dir_node = makeFileNode(pathFileName(path), path);
+        getDirectoryContents(new_dir_node).appendChild(dir_node);
+    };
+
+    // Create default folders
+    if (!FSFileExists("/Resources"))
+        FS.mkdir("/Resources");
+    if (!FSFileExists("/Resources/animations"))
+        FS.mkdir("/Resources/animations");
+    if (!FSFileExists("/Resources/bundles"))
+        FS.mkdir("/Resources/bundles");
+    if (!FSFileExists("/Resources/databases"))
+        FS.mkdir("/Resources/databases");
+    if (!FSFileExists("/Resources/fonts"))
+        FS.mkdir("/Resources/fonts");
+    if (!FSFileExists("/Resources/images"))
+        FS.mkdir("/Resources/images");
+    if (!FSFileExists("/Resources/json"))
+        FS.mkdir("/Resources/json");
+    if (!FSFileExists("/Resources/server"))
+        FS.mkdir("/Resources/server");
+    if (!FSFileExists("/Resources/sounds"))
+        FS.mkdir("/Resources/sounds");
 });

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="stylesheet.css">
 
     <script src="codemirror-5.65.15/lib/codemirror.js"></script>
+    <script src="jszip/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3"
         crossorigin="anonymous"></script>
@@ -40,8 +41,11 @@
                     <button type="button" id="run" class="btn btn-success"><i class="bi bi-play-fill"></i></button>
                 </div>
                 <div class="d-flex flex-column column m-3 justify-content-center" style="color:white;height:16em;vertical-align:position:relative;">
-                    <h3 style="color:white;"> Files </h3>
+                    <div class="d-flex flex-row">
+                        <h3 style="color:white;" class="flex-grow-1"> Files </h3><button class="btn btn-success" id="SaveProject">Save Project</button><button class="btn btn-success" id="LoadProject">Load Project</button>
+                    </div>
                     <input type="file" id="fileuploader" onchange="uploadFileFromInput()" style="display:none;">
+                    <input type="file" id="projectuploader" onchange="uploadProjectFromInput()" style="display:none;">
                     <div style="background-color:#282a36; color:#f8f8f2;top;overflow-y:auto;height:100%;position:relative;flex:1;">
                         <div class="directory node" id="fileView" data-path="" data-label=""><div class="node-label bi-folder2-open">/</div>
                             <div class="directory-contents open-directory"></div>

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -41,6 +41,7 @@
                 </div>
                 <div class="d-flex flex-column column m-3 justify-content-center" style="color:white;height:16em;vertical-align:position:relative;">
                     <h3 style="color:white;"> Files </h3>
+                    <input type="file" id="fileuploader" onchange="uploadFile()" style="display:none;">
                     <div style="background-color:#282a36; color:#f8f8f2;top;overflow-y:auto;height:100%;position:relative;flex:1;">
                         <div class="directory node" id="fileView" data-path="" data-label=""><div class="node-label bi-folder2-open">/</div>
                             <div class="directory-contents open-directory"></div>

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -41,7 +41,7 @@
                 </div>
                 <div class="d-flex flex-column column m-3 justify-content-center" style="color:white;height:16em;vertical-align:position:relative;">
                     <h3 style="color:white;"> Files </h3>
-                    <input type="file" id="fileuploader" onchange="uploadFile()" style="display:none;">
+                    <input type="file" id="fileuploader" onchange="uploadFileFromInput()" style="display:none;">
                     <div style="background-color:#282a36; color:#f8f8f2;top;overflow-y:auto;height:100%;position:relative;flex:1;">
                         <div class="directory node" id="fileView" data-path="" data-label=""><div class="node-label bi-folder2-open">/</div>
                             <div class="directory-contents open-directory"></div>

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -39,33 +39,12 @@
                 <div>
                     <button type="button" id="run" class="btn btn-success"><i class="bi bi-play-fill"></i></button>
                 </div>
-                <div class="column m-3 justify-content-center" style="color:white;height:16em;vertical-align:top;overflow-y:auto;position:relative;">
-                    This is where files go
-                    <div style="background-color:#282a36; color:#f8f8f2;">
-                    <div class="directory node"><div class="node-label bi-folder2-open">Resource</div><div class="directory-contents open-directory">
-                            <div class="directory node"><div class="node-label bi-folder2-open">Sound</div><div class="directory-contents open-directory">
-                                <div class="node file bi-file-music node-label">chipmunk.ogg</div>
-                                <div class="node file bi-file-music node-label">clap.ogg</div>
-                            </div></div>
-                            <div class="directory node"><div class="node-label bi-folder2-open">Graphics</div><div class="directory-contents open-directory">
-                                <div class="node file bi-file-image node-label">chara.png</div>
-                                <div class="node file bi-file-image node-label">happy.jpg</div>
-                            </div></div>
-                            <div class="directory node"><div class="node-label bi-folder2">Json</div><div class="directory-contents closed-directory">
-                                <div class="node file bi-file node-label">chara.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                                <div class="node file bi-file node-label">level2.json</div>
-                            </div></div>
-                            <div class="directory node"><div class="node-label bi-folder2">Misc</div><div class="directory-contents closed-directory">
-                            </div></div>
+                <div class="d-flex flex-column column m-3 justify-content-center" style="color:white;height:16em;vertical-align:position:relative;">
+                    <h3 style="color:white;"> Files </h3>
+                    <div style="background-color:#282a36; color:#f8f8f2;top;overflow-y:auto;height:100%;position:relative;flex:1;">
+                        <div class="directory node" id="fileView" data-path="" data-label=""><div class="node-label bi-folder2-open">/</div>
+                            <div class="directory-contents open-directory"></div>
                         </div>
-                    </div>
                     </div>
                 </div>
             </div>

--- a/Browser_IDE/package.json
+++ b/Browser_IDE/package.json
@@ -13,6 +13,7 @@
     "codemirror": "^5.65.16",
     "compilex": "^0.7.4",
     "express": "^4.18.2",
+    "jszip": "^3.10.1",
     "nodemon": "^3.0.1"
   },
   "description": ""

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -8,7 +8,13 @@
 }
 .node-label{
     width:100%;
+    display:flex;
+    flex-direction: row !important;
     padding: 0px 20px 0px 0px;
+}
+.node-label-text{
+    flex: 1;
+    padding: 0px 0px 0px 3px;
 }
 .node-button{
     background: none;
@@ -29,6 +35,11 @@
 }
 .closed-directory{}
 .open-directory{}
+
+
+[class^="bi-"]::before, [class*=" bi-"]::before {
+    line-height: inherit !important;
+}
 
 
 .in-drag{

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -2,24 +2,33 @@
     color:#f8f8f2;
     cursor: pointer;
 }
+.node-label:hover{
+    background-color:#242732; color:#f8f8f2;
+    cursor: pointer;
+}
 .node-label{
     width:100%;
-    display:inline-block;
+    padding: 0px 20px 0px 0px;
+}
+.node-button{
+    background: none;
+    border: none;
+    color: white;
+    padding: 0;
+    margin: 0;
+}
+.node-button:hover{
+    color: lime;
 }
 
 
 .directory-contents{
     padding:00px 0px 0px 30px;
     transition: max-height 0.3s ease;
-}
-.closed-directory
-{
     overflow:hidden;
 }
-.open-directory
-{
-    overflow:hidden;
-}
+.closed-directory{}
+.open-directory{}
 
 
 .in-drag{


### PR DESCRIPTION
# Description

Adds buttons to download/upload the current project and all resources.
It basically just zips up all visible directories in the virtual file system and downloads the zip; upload is the same but in reverse.

Depends on #10, #12

Fixes NA

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Multiple test projects have been download and uploaded multiple times to ensure no data is lost each time.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request