### PR TITLE
Improved Error Reporting

### DIFF
--- a/Browser_IDE/executionEnvironment.js
+++ b/Browser_IDE/executionEnvironment.js
@@ -15,6 +15,13 @@ class ExecutionEnvironment extends EventTarget{
             if (data.type == "initialized"){
                 EE.dispatchEvent(new Event("initialized"));
             }
+            else if (data.type == "error"){
+                let ev = new Event("error");
+                ev.message = data.message;
+                ev.line = data.line;
+                ev.block = data.block;
+                EE.dispatchEvent(ev);
+            }
             else if (data.type == "FS")
             {
                 if (data.message.type == "onMovePath"){

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -17,6 +17,16 @@ ResetExecutionScope();
 
 function run_within_scope(block, source){
     let res = scope.next(source);
+    if (res.value.state == "error"){
+        stopMainLoop();
+        document.getElementById("output").value += "("+block+") "+res.value.message+"\n";
+        parent.postMessage({
+            type: "error",
+            block: block,
+            message: res.value.message,
+            line: res.value.line
+        },"*");
+    }
 }
 
 let runMainLoopGo = false;

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -3,6 +3,17 @@
 let isInitialized = false;
 
 moduleEvents.addEventListener("onRuntimeInitialized", function() {
+    // Patch open_window so that it cannot be called multiple times.
+    // So far all other functions handle being re-called acceptably,
+    // whereas when open_window is called enough, rendering stops working.
+    // TODO: Update window size if subsequent calls give a different size
+    let original_open_window = open_window;
+    open_window = function(name, w, h){
+        original_open_window(name, w, h);
+        open_window = function(name, w, h){
+            console.log("Window already open, ignoring calling to open_window");
+        }
+    }
     isInitialized = true;
 });
 

--- a/Browser_IDE/executionEnvironment_Scope.js
+++ b/Browser_IDE/executionEnvironment_Scope.js
@@ -13,10 +13,17 @@ function* Execution_Scope(expr) {
             };
         }
         catch(err){
-            console.log(err);
+            let lineNumber = null;
+            let message = "Error: "+err;
+            // TODO: Add support for browsers other than Firefox
+            if (err.hasOwnProperty("lineNumber")){
+                lineNumber = err.lineNumber;
+                message = "Error on line "+lineNumber+": "+err;
+            }
             expr = yield{
                 state: "error",
-                value: err
+                message: message,
+                line: lineNumber,
             };
         }
     }

--- a/Browser_IDE/script.js
+++ b/Browser_IDE/script.js
@@ -94,10 +94,12 @@ function enableCodeExecution(){
 }
 
 function runInitialization(){
+    clearErrorLines(editorInit);
     executionEnviroment.runCodeBlock("Init", editorInit.getValue());
 }
 
 function runMainLoop(){
+    clearErrorLines(editorMainLoop);
     executionEnviroment.runCodeBlock("Main", editorMainLoop.getValue());
 }
 
@@ -295,4 +297,22 @@ document.getElementById("UploadProject").addEventListener("click", function (e) 
 document.getElementById("NewProject").addEventListener("click", async function (e) {
     newProject();
     e.stopPropagation();
+});
+
+// ----- Error Reporting -----
+function clearErrorLines(editor){
+    for (var i = 0; i < editor.lineCount(); i++) {
+        editor.removeLineClass(i, "wrap", "error-line");
+    }
+}
+
+executionEnviroment.addEventListener("error", function(e){
+    let editor = (e.block=="Init"?editorInit:editorMainLoop);
+    if (e.line != null){
+        editor.addLineClass(e.line-1, "wrap", "error-line");
+        editor.scrollIntoView({line:e.line-1, char:0}, 200);
+        editor.setCursor({line:e.line-1, char:0});
+    }
+    editor.focus();
+    pauseMainLoopButton.disabled = true;
 });

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -67,3 +67,8 @@
     right:0px;
     left:0px;
 }
+.error-line{
+    text-decoration-color: #d94747 !important;
+    text-decoration: underline wavy;
+    background-color: #6c514f;
+}


### PR DESCRIPTION
# Description

Errors now stop code execution and print a proper error message so the user can debug them. On Firefox it also prints the line number and highlights it in the code editor. Support for Chrome will also be added soon. 

Additionally, multiple calls to `open_window` are now ignored. Previously, running the Initialization code (where usually `open_window` is called) multiple times, would eventually lead to rendering failing. Now the user can re-run initialization without much issue.

List of changes
 - Pause code on error
 - Print error in on-screen terminal for user
 - (Firefox only) Print line number and highlight in code editor
 - Ignore multiple calls to open_window.

Depends on most previous pull requests (including #16 and #17 ).

Fixes NA

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Errors have been placed in the code and tested to confirm execution pauses.
- Code using open_window has been tested to no longer show rendering issues after multiple executions

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request