### PR TITLE
Show message when project modified in other tab

### DIFF
--- a/Browser_IDE/IDBStoredProject.js
+++ b/Browser_IDE/IDBStoredProject.js
@@ -43,12 +43,13 @@ class IDBStoredProject extends EventTarget{
         if (this.lastKnownWriteTime == 0){
             this.lastKnownWriteTime = storedTime;
         }
-        if (storedTime != this.lastKnownWriteTime)
+        if (storedTime > this.lastKnownWriteTime)
             this.dispatchEvent(new Event("timeConflict"));
     }
 
     detachFromProject(){
         this.projectName = null;
+        this.lastKnownWriteTime = 0;
         this.dispatchEvent(new Event("detached"));
     }
 

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -7,7 +7,7 @@ myTreeView.addEventListener("nodeMoveRequest", function(e){
     if (e.FS.includes("transient"))
         executionEnviroment.rename(e.oldPath, e.newPath);
     if (e.FS.includes("persistent"))
-        storedProject.rename(e.oldPath, e.newPath);
+        storedProject.access((project)=>project.rename(e.oldPath, e.newPath));
 });
 
 myTreeView.addEventListener("nodeDoubleClick", function(e){
@@ -57,8 +57,8 @@ storedProject.addEventListener('onOpenFile', function(e) {
 });
 
 
-storedProject.addEventListener("initialized", async function() {
-    let fileTree = await storedProject.getFileTree();
+storedProject.addEventListener("attached", async function() {
+    let fileTree = await storedProject.access((project)=>project.getFileTree());
     myTreeView.populatefileView(fileTree, "persistent");
 });
 

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -97,6 +97,7 @@
 <script src="executionEnvironment.js"></script>
 <script src="IDBStoredProject.js"></script>
 <script src="projectInitializer.js"></script>
+<script src="modal.js"></script>
 <script src="script.js"></script>
 <script src="treeview.js"></script>
 <script src="fileview.js"></script>

--- a/Browser_IDE/modal.js
+++ b/Browser_IDE/modal.js
@@ -1,0 +1,46 @@
+"use strict";
+
+// Thin wrapper around Bootstrap, in case we stop using it later
+function createModal(name, title, content, primaryButton, secondaryButton = null){
+
+    let modal = document.createElement("div");
+
+    // Create via string template...
+    let modalString = [
+    '<div id="'+name+'" tabindex="-1" class="modal fade" aria-hidden="true" aria-labelledby="exampleModalLabel">',
+    '  <div class="modal-dialog">',
+    '    <div class="modal-content bg-dark text-bg-dark">',
+    '      <div class="modal-header">',
+    '        <h5 class="modal-title">'+title+'</h5>',
+    '        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>',
+    '      </div>',
+    '      <div class="modal-body">',
+    '        '+content+'',
+    '      </div>',
+    '      <div class="modal-footer">',
+    '      </div>',
+    '    </div>',
+    '  </div>',
+    '</div>'].join("\n");
+
+    modal.innerHTML = modalString;
+
+    if (secondaryButton != null){
+        var sButton = document.createElement("button");
+        sButton.classList.add("btn","btn-secondary");
+        sButton.innerText = secondaryButton.label;
+        sButton.onclick = secondaryButton.callback;
+        modal.getElementsByClassName("modal-footer")[0].appendChild(sButton);
+    }
+    if (primaryButton != null){
+        var pButton = document.createElement("button");
+        pButton.classList.add("btn","btn-success");
+        pButton.innerText = primaryButton.label;
+        pButton.onclick = primaryButton.callback;
+        modal.getElementsByClassName("modal-footer")[0].appendChild(pButton);
+    }
+
+    document.body.appendChild(modal);
+
+    return new bootstrap.Modal(modal.childNodes[0], {});
+}


### PR DESCRIPTION
# Description

Currently, the database the user's project is stored in is locked upon opening, meaning if SplashKit Online is loaded in a second tab, it appears unresponsive as it waits for the database to be available again. This pull request modifies the following:
 - `IDBStoredProject` no longer holds a connection to the database across its lifetime, and instead opens the database only when performing operations. The operations (like `mkdir`, `writeFile`, etc) are no longer directly available. These operations are performed via the `access` function, which takes a function. It creates a `__IDBStoredProjectRW`, which contains functions to modify the project, and opens the database via it, then passes it into the function. After the function finishes, the `access` function then closes the connection.
 - Now an IDBStoredProject contains a lastWriteTime, which is automatically updated before closing the database each 'access', if a write has been performed.
 - Finally, the lastWriteTime is periodically polled, and if it has increased without any operations occurring within the tab, a `timeConflict` event is raised, which causes a modal to be shown warning the user that they could lose work if they don't reload the tab - and contains a button to reload the tab now.

Fixes NA

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Two tabs have been opened, and projects opened/closed/modified between them, ensuring the modal pops up each time on the other tab. 
- To ensure IDBStoredProject still functions, files have been uploaded, projects have been loaded, and New Project has been pressed.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request