### PR TITLE
Fix Bugs in Code Processing and Error Messages

### DIFF
--- a/Browser_IDE/executionEnvironment_CodeProcessor.js
+++ b/Browser_IDE/executionEnvironment_CodeProcessor.js
@@ -206,10 +206,6 @@ function makeFunctionsAsyncAwaitTransform(babel){
 
             // Modify calls to user functions to 'await' their return value
             CallExpression: (path) => {
-                if (path.getFunctionParent() == null){
-                    path.skip();
-                    return;
-                }
                 const statement = path.node;
                 if (findGlobalDeclarationsTransform__userScope.has(path.node.callee.name) && (path.container.type != "AwaitExpression"))
                     path.replaceWith(types.awaitExpression(statement));
@@ -290,6 +286,7 @@ function processCodeForExecutionEnvironment(userCode, asyncStopName, asyncPauseN
         plugins: ["findGlobalDeclarationsTransform"]
     });
 
+    // Now do the actual transforms!
     userCode = Babel.transform(userCode, {
         plugins: ["makeFunctionsAsyncAwaitTransform","asyncify"],
         retainLines: true

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -1,5 +1,27 @@
 "use strict";
 
+let userCodeBlockIdentifier = "__USERCODE__";
+let userCodeStartLineOffset = findAsyncFunctionConstructorLineOffset();
+
+// In Firefox at least, the AsyncFunction constructor appends two lines of code to
+// the start of the function.
+// So we'll detect where a dummy identifier inserted on the first line of the code
+//  is located (*/SK_ID*/), and update userCodeStartLineOffsets.
+// Could just set it to 2, but unsure if this is browser/source dependent or not.
+function findAsyncFunctionConstructorLineOffset(){
+    let identifier = "/*SK_ID*/";
+    let blockFunction = Object.getPrototypeOf(async function() {}).constructor(
+        "\"use strict\";"+identifier+"\n;"
+    );
+    let functionCode = blockFunction.toString();
+    let codeUntilIdentifier = functionCode.slice(0, functionCode.indexOf(identifier));
+    let newlines = codeUntilIdentifier.match(/\n/g);
+    let newlineCount = ((newlines==null)?0:newlines.length);
+
+    return newlineCount;
+}
+
+
 let isInitialized = false;
 
 moduleEvents.addEventListener("onRuntimeInitialized", function() {
@@ -35,6 +57,17 @@ moduleEvents.addEventListener("onRuntimeInitialized", function() {
 // Convenience function for reporting errors, printing them to the terminal
 // and also sending a message to the main window.
 function ReportError(block, message, line){
+    if (line != null)
+        message = "Error on line "+line+": "+message;
+
+    if (!block.startsWith(userCodeBlockIdentifier)){
+        message = "Please file a bug report and send us the following info!\n    Error in file: "+block+"\n    "+message;
+        block = "Internal Error";
+    }
+    else{
+        block = block.slice(userCodeBlockIdentifier.length);
+    }
+
     document.getElementById("output").value += "("+block+") "+message+"\n";
     parent.postMessage({
         type: "error",
@@ -51,27 +84,9 @@ function ResetExecutionScope(){
     }
 }
 
-async function tryRunFunction_Internal(func) {
-    try{
-        let run = null;
-        run = await func();
-        return{
-            state: "success",
-            value: run
-        };
-    }
-    catch(err){
-        if (err instanceof ForceBreakLoop){
-            return{
-                state: "stopped",
-                value: run
-            };
-        }
-
-
-        // Parse the non-standard exceptions stack with a regex,
-        // that returns file and line number.
-        // For reference, here's some example stacks:
+// Parse the non-standard exceptions stack with a regex,
+// that returns file and line number.
+// For reference, here's some example stacks:
 // Firefox:
 /*
 gameInnerLoop@Init.js`;:25:25
@@ -93,26 +108,54 @@ ReferenceError: test is not defined
     at async :8000/runProgram (http://localhost:8000/executionEnvironment_Internal.js:132:9)}
     at gameInnerLoop (Init.js`;:25:7)
 */
-        // Currently those are the only two forms supported, but this should account for the majority well enough.
-        // It also doesn't parse the url style ones - it only needs to work for the local user's code, so good enough.
+// Currently those are the only two forms supported, but this should account for the majority well enough.
+// It also doesn't parse the url style ones - it only needs to work for the local user's code, so good enough.
 
-        const stackParse = /(?:@|\()([^;:`]*)`?;?:([0-9]*)/g;
-        let stack = [...err.stack.matchAll(stackParse)];
-        let lineNumber = null;
+function parseErrorStack(err){
+    const stackParse = /(?:@|\()((?:[^;:`]|[:;`](?=.*(?:\/|\.)))*)`?;?:([0-9]*)/g;
+    let stack = [...err.stack.matchAll(stackParse)];
 
-        lineNumber = stack[0][2];
-        let message = "Error on line "+lineNumber+": "+err;
+    let lineNumber = stack[0][2];
+
+    let file = stack[0][1];
+
+    if (file.startsWith(userCodeBlockIdentifier))
+        lineNumber -= userCodeStartLineOffset;
+
+    return {lineNumber, file};
+}
+
+
+async function tryRunFunction_Internal(func, block=null) {
+    try{
+        let run = null;
+        run = await func();
+        return{
+            state: "success",
+            value: run
+        };
+    }
+    catch(err){
+        if (err instanceof ForceBreakLoop){
+            return{
+                state: "stopped",
+                value: run
+            };
+        }
+
+        let error = parseErrorStack(err, block);
+
         return{
             state: "error",
-            message: message,
-            line: lineNumber,
-            block: stack[0][1],
+            message: err,
+            line: error.lineNumber,
+            block: error.file,
         };
     }
 }
 
 // Run a function
-async function tryRunFunction(func, reportError = true){
+async function tryRunFunction(func){
     let res = await tryRunFunction_Internal(func);
     if (res.state == "error"){
         stopProgram();
@@ -120,10 +163,33 @@ async function tryRunFunction(func, reportError = true){
     }
     return res;
 }
-async function tryEvalSource(block, source, reportError = true){
-    return await tryRunFunction(function(){
-        (0,eval)("\"use strict\";"+source+"\n//# sourceURL="+block+"`;");
-    }, reportError);
+
+// This function will attempt to create an AsyncFunction from the user's source code.
+// This should pass, as the user's code was already syntax checked earlier outside the iFrame.
+// But just in case, check it anyway.
+async function createEvalFunctionAndSyntaxCheck(block, source){
+    let res = await tryRunFunction_Internal(function (){
+        return Object.getPrototypeOf(async function() {}).constructor(
+            "\"use strict\";"+source+"\n//# sourceURL="+userCodeBlockIdentifier+block
+        );
+    });
+    if (res.state == "error"){
+        ReportError(res.block, res.message, res.line);
+    }
+    return res;
+}
+
+async function tryEvalSource(block, source){
+    // First create and syntax check the function
+    let blockFunction = await createEvalFunctionAndSyntaxCheck(block, source);
+
+    if (blockFunction.state != "success")
+        return blockFunction;
+
+    return await tryRunFunction(
+        blockFunction.value,
+        reportError
+    );
 }
 
 let mainIsRunning = false;
@@ -147,8 +213,8 @@ function continueProgram(){
     }
 }
 async function runProgram(){
-    if (window.main === undefined){
-        ReportError("Program", "There is no main() function to run!", null);
+    if (window.main === undefined || !(window.main instanceof Function)){
+        ReportError(userCodeBlockIdentifier+"Program", "There is no main() function to run!", null);
         return;
     }
     if (!mainIsRunning){
@@ -174,16 +240,22 @@ window.addEventListener('message', function(m){
     if (m.data.type == "RunCodeBlock"){
         let processedCode = "";
         try {
+            // At this point, the code has already been syntax checked outside of the iFrame, so we
+            // should have no trouble here.
             processedCode = processCodeForExecutionEnvironment(m.data.code, "mainLoopStop", "mainLoopPause", "mainLoopContinuer", "onProgramPause");
 
             tryEvalSource(m.data.name, processedCode);
         }
         catch(e) {
-            // If we got a syntax error, we prefer the browser's messages over Babel's - they're more user friendly.
-            // Attempt to eval the code (knowing it has a syntax error) so we get the browser's message.
-            tryEvalSource(m.data.name, m.data.code);
-            // TODO: Check that it didn't actually run by accident. Perhaps add a deliberate syntax error at the end?
+            // If we got a syntax error from Babel, we know the browser can't return a more user friendly
+            // one since it didn't report one initially. So for now just report Unknown error.
+            // TODO: Report Babel's syntax error.
+            ReportError(userCodeBlockIdentifier+m.data.name, "Unknown syntax error.", null);
         }
+    }
+
+    if (m.data.type == "ReportError"){
+        ReportError(userCodeBlockIdentifier + m.data.block, m.data.message, m.data.line);
     }
 
     if (m.data.type == "CleanEnvironment"){

--- a/Browser_IDE/script.js
+++ b/Browser_IDE/script.js
@@ -220,9 +220,14 @@ async function restartProgram(){
         await executionEnviroment.stopProgram(); // Make sure we wait for it to stop via await.
     executionEnviroment.cleanEnvironment();
 
-    runAllCodeBlocks();
+    // The syntax checking cannot run inside an async function,
+    // so just runAllCodeBlocks (which does syntax checking)
+    // inside a timeout instead. A bit of a cludge, but it works.
+    setTimeout(function(){
+        runAllCodeBlocks();
 
-    executionEnviroment.runProgram();
+        executionEnviroment.runProgram();
+    }, 0);
 }
 
 // ------ Setup code editor buttons ------
@@ -251,35 +256,35 @@ updateButtons();
 
 
 // Add events for the code blocks
-runInitButton.addEventListener("click", async function () {
+runInitButton.addEventListener("click", function () {
     saveInitialization();
     runInitialization();
 });
 
-runMainLoopButton.addEventListener("click", async function () {
+runMainLoopButton.addEventListener("click", function () {
     saveMainLoop();
     runMainLoop();
 });
 
 
 // Add events for the main program buttons
-runProgramButton.addEventListener("click", async function () {
+runProgramButton.addEventListener("click", function () {
     saveMainLoop();
     saveInitialization();
     runProgram();
 });
 
-stopProgramButton.addEventListener("click", async function () {
+stopProgramButton.addEventListener("click", function () {
     pauseProgram();
 });
 
-restartProgramButton.addEventListener("click", async function () {
+restartProgramButton.addEventListener("click", function () {
     saveMainLoop();
     saveInitialization();
     restartProgram();
 });
 
-continueProgramButton.addEventListener("click", async function () {
+continueProgramButton.addEventListener("click", function () {
     saveMainLoop();
     saveInitialization();
     continueProgram();
@@ -463,6 +468,8 @@ executionEnviroment.addEventListener("programStopped", function(e){
 executionEnviroment.addEventListener("error", function(e){
     let editor = (e.block=="GeneralCode"?editorInit:editorMainLoop);
     if (e.line != null){
+        if (editor.lineCount() < e.line)
+            e.line = editor.lineCount();
         editor.addLineClass(e.line-1, "wrap", "error-line");
         editor.scrollIntoView({line:e.line-1, char:0}, 200);
         editor.setCursor({line:e.line-1, char:0});


### PR DESCRIPTION
# Description

This pull request fixes various bugs in error messages and code processing. Previously, the user could not call user functions inside the global scope (such as in global declarations and such), as they would not be called with `async`. Additionally, the latest cross-browser error reports change had a regression - syntax errors would not be reported properly. This pull request fixes these two problems, and also improves how it reports internal errors to the user.

Due to limited browser support for this sort of functionality, the code ended up tied together in some unfortunate ways, but I've tried to document the source code where important to make it clear how each piece interacts.

Note:
The only cross browser way to syntax check the user's function and get a line number was to use window.onerror. Unfortunately, due to the sandboxed nature of the iFrame, the resulting information just became "Syntax error", with line/column as 0s. So instead it now performs syntax checking _outside_ the iFrame first. Once the code is running (inside the iFrame), the stack traces become more useful and everything can all be handled in there. It's only the syntax check that runs outside outside, so this should be safe from a security point of view.
 
Detailed list of changes:
 - Fix bug in cross-browser error checking - syntax errors didn't work!
   - Now handle syntax errors outside the iFrame via onerror
   - Lot's of small changes to make this work - not very clean
 - Improve stack parsing regex
 - Detect if error came from user code -  if not, report it as Internal
 - Allow async function call in global space
 - Execute user initialization code as async function - no more eval!
 - Improve detection of when there's no 'main' function


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Syntax errors and runtime errors have been created and tested to ensure the correct line number is identified.
- Code with user functions/classes being used in the global scope has been tested (in fact, I tried the original version of the Cave Escape port, which still had the Init/MainLoop separation. It successfully runs for a single frame before reaching the end of the program!)
- Causing errors outside the user code has been tested, to ensure the error message returned tells the user it was an internal error.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request