### PR TITLE
In-repo SplashKit Wasm Library Building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 node_modules/
 temp/
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+out/
+splashkit/
+generated/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "SplashKitWasm/splashkit-core"]
+	path = SplashKitWasm/external/splashkit-core
+	url = https://github.com/thoth-tech/splashkit-core.git
+	ignore = dirty

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Installation involves two steps.
 ### Setting up the IDE
 The IDE is just a simple node project with few dependencies, and can be setup with the following lines:
 ```bash
-git clone https://github.com/WhyPenguins/SplashkitOnline.git
+git clone --recursive https://github.com/WhyPenguins/SplashkitOnline.git
 cd SplashkitOnline/Browser_IDE/
-npm install codemirror@5
+npm install
 npm run server
 ```
 Now you'll be able to load up `localhost:8000` in a browser and see the IDE! However, we also need to import the SplashKit library, as its not included in the repository by default. 
@@ -48,19 +48,15 @@ You can find unofficial pre-built files [here](https://github.com/WhyPenguins/Sp
 Manual compilation is a little more involved.
 First you'll need to install Emscripten, which will be used to compile SplashKit to Wasm so it can be used in the browser. The easiest way to do this is via the `emsdk`. Installation instructions are here - [Getting Started](https://emscripten.org/docs/getting_started/downloads.html)
 
-Once you've got Emscripten installed and activated, you can compile the SplashKit Wasm library!
-First checkout the unofficial Wasm build repository.
+Once you've got Emscripten installed and activated, you can compile the SplashKit Wasm library! We've included SplashKit's source code as a submodule, along with the scripts to compile it as a Wasm library, directly in this repo.
+
+Currently only cmake builds are supported, so navigate to the cmake project and build it using Emscripten's `emcmake` and `emmake` wrappers.
 ```bash
-git clone --recursive https://github.com/WhyPenguins/splashkit-core
-```
-Currently only cmake builds are supported, so navigate to the cmake project and build it using Emscripten's `emcmake` and `emmake` wrappers. We also need to setup an additional environment variable - this will hopefully not be necessary in the future.
-```bash
-cd splashkit-core\projects\cmake
-SET EMSCRIPTEN=%EMSDK%/upstream/emscripten #or if on linux, the bash equivalent
+cd SplashkitOnline\SplashKitWasm\cmake
 emcmake cmake -G "Unix Makefiles" .
 emmake make
 ```
-If all goes well, you should find the three files inside `out/lib/` - just copy them into `Browser_IDE/splashkit/` and you're done!
+If all goes well, you should find the three files built and copied to inside `Browser_IDE/splashkit/` - if so, you're done!
 
 ## Project Goals and Structure
 The goal of the SplashKit Online IDE is to provide a beginner friendly programming environment targeted towards using the SplashKit library. It has REPL like functionality to allow rapid feedback, with emphasis on game related functionality like interactivity, graphics rendering and audio playback. To support this, code execution should definitely happen in the browser (hence compiling SplashKit to run in the browser), and ideally compilation does as well. Currently Javascript is the only language supported (as it is quite easy to execute in a browser), however work on involving other languages is also under way.
@@ -70,7 +66,7 @@ The goal of the SplashKit Online IDE is to provide a beginner friendly programmi
 The IDE is written as simply as possible, using straight HTML, CSS and Javascript. The code editors use the CodeMirror library (version 5) to provide syntax highlighting and other editing features. It is currently ran by using node for some reason, however as demonstrated by the unofficial demo, any sort of static page server can do the trick (such as `python -m http.server`)
 
 ### Code Execution
-Currently Javascript is the only language supported in the IDE, and it is currently executed using an `eval` command. There are plans to improve this to run the user's code inside an iFrame to prevent accidentally affecting the IDE itself. 
+Currently Javascript is the language supported by the IDE, and it is executed securely inside an iFrame after some code transformations to make it run asynchronously and within a custom scope.
 
 The SplashKit API has been exposed to the global scope of Javascript, allowing the user to interface with it in much the same way they can in other languages, like C++ and Python. Calls to the SplashKit API are then executed by the SplashKit Wasm module as native code (or as native as it gets in a browser).
 

--- a/SplashKitWasm/cmake/CMakeLists.txt
+++ b/SplashKitWasm/cmake/CMakeLists.txt
@@ -1,0 +1,367 @@
+cmake_minimum_required(VERSION 3.2)
+project(splashkit)
+
+cmake_policy(SET CMP0083 NEW)
+include(CheckPIESupported)
+check_pie_supported()
+
+# SK Directories relative to cmake project
+set(SK_CMAKE "${CMAKE_CURRENT_SOURCE_DIR}/../external/splashkit-core/projects/cmake")
+
+set(SK_SRC "${SK_CMAKE}/../../coresdk/src")
+set(SK_EXT "${SK_CMAKE}/../../coresdk/external")
+set(SK_LIB "${SK_CMAKE}/../../coresdk/lib")
+set(SK_BIN "${SK_CMAKE}/../../bin")
+set(SK_WASMEXT "${CMAKE_CURRENT_SOURCE_DIR}/..")
+set(SK_BROWSERIDE "${CMAKE_CURRENT_SOURCE_DIR}/../../Browser_IDE")
+set(SK_OUT "${SK_WASMEXT}/out")
+
+# Check if compiling properly with emcmake/emmake
+if (NOT EMSCRIPTEN)
+  message(FATAL_ERROR "================================\nPlease re-run via Emscripten emmake/emcmake!\nAlso next time, run with --fresh once to\nclear the cache, or it'll show the same error.\n================================")
+endif()
+
+IF(NOT DEFINED ENV{EMSDK})
+  message(SEND_ERROR "==========================================\nPlease activate Emscripten before running!\n(use emsdk_env.bat/sh)\n==========================================")
+ENDIF()
+
+
+if (WIN32 OR MSYS OR MINGW)
+  SET(MSYS "true")
+  add_definitions(-DWINDOWS)
+endif()
+
+if(EMSCRIPTEN)
+  SET(MSYS "false")
+endif()
+
+#### SETUP ####
+if (APPLE)
+    # MAC OS PROJECT FLAGS
+    add_link_options("-Wl-U,___darwin_check_fd_set_overflow")
+    set(LIB_FLAGS "-L${SK_LIB}/mac \
+                   -framework IOKit \
+                   -framework ForceFeedback \
+                   -framework CoreFoundation \
+                   -framework Metal \
+                   -framework Cocoa \
+                   -framework Carbon \
+                   -framework AudioUnit \
+                   -framework AudioToolbox \
+                   -framework CoreAudio \
+                   -framework CoreVideo \
+                   -lSDL2 \
+                   -lSDL2_mixer \
+                   -lSDL2_ttf \
+                   -lSDL2_gfx \
+                   -lSDL2_image \
+                   -lSDL2_net \
+                   -lpthread \
+                   -lbz2 \
+                   -lFLAC \
+                   -lvorbis \
+                   -lz \
+                   -lpng16 \
+                   -lvorbisfile \
+                   -logg \
+                   -lwebp \
+                   -lcurl \
+                   -lncurses \
+                   -liconv \
+                   -ldl")
+# WINDOWS PROJECT FLAGS
+elseif(MSYS)
+    string(COMPARE EQUAL "MINGW32" "$ENV{MSYSTEM}" MINGW32)
+    string(COMPARE EQUAL "MINGW64" "$ENV{MSYSTEM}" MINGW64)
+
+    if (${MINGW32})
+        message("Using mingw32")
+        set(OS_PATH_SUFFIX "win32")
+        set(MINGW_PATH_PART "mingw32")
+    elseif (${MINGW64})
+        message("Using mingw64")
+        set(OS_PATH_SUFFIX "win64")
+        set(MINGW_PATH_PART "mingw64")
+    else ( )
+        message(SEND_ERROR "Failed to detect windows architecture")
+        return ()
+    endif()
+
+    set(LIB_FLAGS  "-L${SK_LIB}/${OS_PATH_SUFFIX} \
+                    -L/${MINGW_PATH_PART}/lib \
+                    -L/usr/lib \
+                    -lSDL2main")
+# EMSCRIPTEN PROJECT FLAGS
+elseif(EMSCRIPTEN)
+    message("Using emscripten")
+    set(LIB_FLAGS "-lpthread \
+                   -ldl \
+                   -s LINKABLE=1 \
+                   -s EXPORT_ALL=1 \
+                   -sUSE_SDL=2 \
+                   -sUSE_SDL_TTF=2 \
+                   -sUSE_SDL_GFX=2 \
+                   -sUSE_SDL_NET=2 \
+                   -sUSE_SDL_MIXER=2 \
+                   -sUSE_SDL_IMAGE=2 \
+                   -sSDL2_IMAGE_FORMATS='[\"bmp\",\"png\",\"xpm\"]'")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -sUSE_SDL=2")
+
+    file(GLOB BUILD_AS_WINDOWS_FILES
+        "${SK_EXT}/civetweb/src/civetweb.c"
+        "${SK_EXT}/sqlite/sqlite3.c"
+        "${SK_EXT}/hash-library/*.cpp"
+        "${SK_SRC}/coresdk/terminal.cpp"
+    )
+    file(GLOB BUILD_AS_LINUX_FILES
+        "${SK_EXT}/easyloggingpp/*.cc"
+    )
+
+    set_source_files_properties(${BUILD_AS_WINDOWS_FILES} PROPERTIES COMPILE_DEFINITIONS "WINDOWS")
+    set_source_files_properties(${BUILD_AS_LINUX_FILES} PROPERTIES COMPILE_DEFINITIONS "__linux")
+    set(CMAKE_EXECUTABLE_SUFFIX ".html")
+
+# LINUX PROJECT FLAGS
+else()
+    set(LIB_FLAGS "-lSDL2 \
+                   -lSDL2_mixer \
+                   -lSDL2_ttf \
+                   -lSDL2_gfx \
+                   -lSDL2_image \
+                   -lSDL2_net \
+                   -lpthread \
+                   -lbz2 \
+                   -lFLAC \
+                   -lvorbis \
+                   -lz \
+                   -lpng16 \
+                   -lvorbisfile \
+                   -logg \
+                   -lwebp \
+                   -lfreetype \
+                   -lcurl \
+                   -lncurses \
+                   -ldl \
+                   -lstdc++fs")
+endif()
+
+# FLAGS
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
+# SOURCE FILES
+file(GLOB SOURCE_FILES
+    "${SK_SRC}/coresdk/*.cpp"
+    "${SK_SRC}/backend/*.cpp"
+    "${SK_EXT}/civetweb/src/civetweb.c"
+    "${SK_EXT}/sqlite/sqlite3.c"
+    "${SK_EXT}/hash-library/*.cpp"
+    "${SK_EXT}/easyloggingpp/*.cc"
+)
+
+if (EMSCRIPTEN)
+  file(GLOB WASM_SOURCE_FILES
+    "${SK_WASMEXT}/stubs/*.cpp"
+  )
+  set(SOURCE_FILES ${SOURCE_FILES} ${WASM_SOURCE_FILES})
+endif()
+
+# TEST FILE INCLUDES
+file(GLOB TEST_SOURCE_FILES
+    "${SK_SRC}/test/*.cpp"
+)
+
+file(GLOB UNIT_TEST_SOURCE_FILES
+    "${SK_SRC}/test/unit_tests/*.cpp"
+)
+
+# SKSDK FILE INCLUDES
+file(GLOB INCLUDE_FILES
+    "${SK_SRC}/coresdk/*.h"
+)
+
+# DIRECTORY INCLUDES
+include_directories("${SK_SRC}")
+include_directories("${SK_SRC}/coresdk")
+include_directories("${SK_SRC}/backend")
+include_directories("${SK_SRC}/test")
+include_directories("${SK_EXT}/civetweb/include")
+include_directories("${SK_EXT}/easyloggingpp")
+include_directories("${SK_EXT}/hash-library")
+include_directories("${SK_EXT}/json")
+include_directories("${SK_EXT}/sqlite")
+include_directories("${SK_EXT}/catch")
+
+# MAC OS AND WINDOWS DIRECTORY INCLUDES
+if (APPLE OR MSYS OR EMSCRIPTEN)
+    include_directories("${SK_EXT}/SDL/include")
+    include_directories("${SK_EXT}/SDL_gfx")
+    include_directories("${SK_EXT}/SDL_image")
+    include_directories("${SK_EXT}/SDL_mixer")
+    include_directories("${SK_EXT}/SDL_net")
+    include_directories("${SK_EXT}/SDL_ttf")
+endif()
+# MAC OS ONLY DIRECTORY INCLUDES
+if (APPLE)
+    include_directories("${SK_EXT}/SDL_image/external/libpng-1.6.2")
+endif()
+# WINDOWS ONLY DIRECTORY INCLUDES
+if (MSYS OR EMSCRIPTEN)
+    include_directories(/${MINGW_PATH_PART}/include)
+    include_directories(/${MINGW_PATH_PART}/include/libpng16)
+    include_directories("${SK_LIB}/win_inc")
+    include_directories("${SK_EXT}/sqlite")
+endif()
+
+# MACRO DEFINITIONS #
+add_definitions(-DELPP_THREAD_SAFE)
+
+#### END SETUP ####
+#### SplashKitBackend STATIC LIBRARY ####
+add_library(SplashKitBackend STATIC ${SOURCE_FILES} ${INCLUDE_FILES})
+
+target_link_libraries(SplashKitBackend ${LIB_FLAGS})
+
+if (EMSCRIPTEN)
+    # Ensure the 'generated' folder exists
+    add_custom_target(WASMBindingsDirectory ALL
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${SK_WASMEXT}/generated/")
+
+    # Auto generate C++ Javascript Glue code from IDL bindings (the next dependency)
+    add_custom_target( WASMBindings ALL DEPENDS "${SK_WASMEXT}/generated/SplashKitWasm.idl" "${SK_WASMEXT}/generated/SplashKitWasmGlue.cpp")
+
+    add_custom_command(
+        DEPENDS "${SK_WASMEXT}/generated/SplashKitWasm.idl"
+        OUTPUT "${SK_WASMEXT}/generated/SplashKitWasmGlue.cpp" "${SK_WASMEXT}/generated/SplashKitWasmGlue.js"
+        COMMENT "Generating Bindings..."
+        COMMAND
+        python "$ENV{EMSDK}/upstream/emscripten/tools/webidl_binder.py" "${SK_WASMEXT}/generated/SplashKitWasm.idl" "${SK_WASMEXT}/generated/SplashKitWasmGlue")
+
+    add_dependencies(WASMBindings WASMBindingsDirectory)
+
+    # Auto generate IDL bindings first
+    add_custom_target( WebIDLBindings ALL DEPENDS "${SK_CMAKE}/../../generated/docs/api.json")
+
+    add_custom_command(
+        DEPENDS "${SK_CMAKE}/../../generated/docs/api.json" "${SK_WASMEXT}/tools/generateWebIDLBindings.py"
+        OUTPUT "${SK_WASMEXT}/generated/SplashKitWasmGlueWrapper.cpp" "${SK_WASMEXT}/generated/SplashKitWasm.idl" "${SK_OUT}/wasmlib/SplashKitGlobalAPI.js"
+        COMMENT "Generating Web IDL Bindings..."
+        COMMAND
+        python "${SK_WASMEXT}/tools/generateWebIDLBindings.py" "${SK_CMAKE}/../../generated/docs/api.json" "${SK_WASMEXT}/generated/SplashKitWasmGlueWrapper.cpp" "${SK_WASMEXT}/generated/SplashKitWasm.idl" "${SK_OUT}/wasmlib/SplashKitGlobalAPI.js")
+
+    add_dependencies(WASMBindings WebIDLBindings)
+
+endif()
+
+if (MSYS)
+    add_definitions(-DWINDOWS)
+    link_directories("${SK_LIB}/${OS_PATH_SUFFIX}")
+    target_link_libraries(SplashKitBackend SDL2_mixer
+                                           SDL2_image
+                                           SDL2_net
+                                           libcivetweb
+                                           SDL2
+                                           SDL2_ttf
+                                           libcurl
+                                           libSDL2_gfx-1-0-0
+                                           libpng16-16
+                                           libsqlite
+                                           pthread
+                                           stdc++
+                                           ws2_32
+                                           libncursesw
+                                           )
+elseif(APPLE)
+    # To make a universal single static library from dependent
+    # static libraries, run libtool on SplashKitBackend
+    file(GLOB APPLE_STATIC_LIBS
+        "${SK_LIB}/mac/*.a"
+    )
+    add_custom_command(TARGET SplashKitBackend POST_BUILD
+      COMMAND /usr/bin/libtool -static -o $<TARGET_FILE:SplashKitBackend>
+      $<TARGET_FILE:SplashKitBackend> ${APPLE_STATIC_LIBS}
+    )
+endif()
+
+
+# SET OUTPUT TO /path/to/splashkit/out/lib
+set_target_properties(SplashKitBackend
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${SK_OUT}/lib"
+)
+
+#### END SplashKitBackend STATIC LIBRARY ####
+#### SplashKitBackend WASM LIBRARY ####
+if (EMSCRIPTEN)
+    add_executable(SplashKitBackendWASM "${SK_WASMEXT}/generated/SplashKitWasmGlueWrapper.cpp")
+    set_target_properties(SplashKitBackendWASM PROPERTIES LINK_FLAGS "-sFS_DEBUG --post-js ${SK_WASMEXT}/generated/SplashKitWasmGlue.js")
+    target_link_libraries(SplashKitBackendWASM SplashKitBackend)
+    set_target_properties(SplashKitBackendWASM
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${SK_OUT}/wasmlib"
+    )
+    add_dependencies(SplashKitBackendWASM WASMBindings)
+    set_target_properties(SplashKitBackendWASM PROPERTIES SUFFIX ".js")
+    # Copy built library to the IDE
+    add_custom_command(TARGET SplashKitBackendWASM
+        POST_BUILD COMMAND
+        ${CMAKE_COMMAND} -E copy_directory "${SK_OUT}/wasmlib" $"${SK_BROWSERIDE}/splashkit")
+
+    add_custom_command(TARGET SplashKitBackendWASM POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan
+                   "Copied built library to the IDE!")
+
+endif()
+#### END SplashKitBackend WASM LIBRARY ####
+#### sktest EXECUTABLE ####
+add_executable(sktest ${TEST_SOURCE_FILES})
+set_property(TARGET sktest PROPERTY POSITION_INDEPENDENT_CODE FALSE)
+
+target_link_libraries(sktest SplashKitBackend)
+target_link_libraries(sktest ${LIB_FLAGS})
+
+# target_link_options(sktest PUBLIC "LINKER:-U,___darwin_check_fd_set_overflow")
+
+set_target_properties(sktest
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${SK_BIN}
+)
+
+# Copy resources folder in
+add_custom_command(TARGET sktest
+    PRE_BUILD COMMAND
+    ${CMAKE_COMMAND} -E copy_directory "${SK_SRC}/test/Resources" $<TARGET_FILE_DIR:sktest>/Resources)
+
+
+if (EMSCRIPTEN)
+    set_target_properties(sktest PROPERTIES LINK_FLAGS "--preload-file ${SK_SRC}/test/Resources@Resources")
+endif()
+
+# if (MSYS)
+#     add_custom_command(TARGET sktest
+#         PRE_BUILD COMMAND
+#         cmake -E copy ../../coresdk/lib/win64/*.dll ../../bin
+#         )
+# endif()
+
+#### END sktest EXECUTABLE ####
+
+#### skunit_tests EXECUTABLE ####
+add_executable(skunit_tests ${UNIT_TEST_SOURCE_FILES})
+set_property(TARGET skunit_tests PROPERTY POSITION_INDEPENDENT_CODE FALSE)
+
+# target_link_options(skunit_tests PUBLIC "LINKER:-U,___darwin_check_fd_set_overflow")
+target_link_libraries(skunit_tests SplashKitBackend)
+target_link_libraries(skunit_tests ${LIB_FLAGS})
+
+if (EMSCRIPTEN)
+    set_target_properties(skunit_tests PROPERTIES LINK_FLAGS "--preload-file ${SK_SRC}/test/Resources@Resources")
+endif()
+
+set_target_properties(skunit_tests
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${SK_BIN}
+        )
+#### END sktest EXECUTABLE ####
+
+install(TARGETS SplashKitBackend DESTINATION lib)
+install(FILES ${INCLUDE_FILES} DESTINATION include/SplashKitBackend)

--- a/SplashKitWasm/stubs/curl.cpp
+++ b/SplashKitWasm/stubs/curl.cpp
@@ -1,0 +1,19 @@
+#include "curl/curl.h"
+
+CURL_EXTERN CURLcode curl_global_init(long flags){return CURLE_OK;}
+CURL_EXTERN void curl_global_cleanup(void){}
+
+CURL_EXTERN CURL *curl_easy_init(void){return nullptr;}
+CURL_EXTERN CURLcode curl_easy_setopt(CURL *curl, CURLoption option, ...){return CURLE_OK;}
+CURL_EXTERN CURLcode curl_easy_perform(CURL *curl){return CURLE_OK;}
+CURL_EXTERN void curl_easy_cleanup(CURL *curl){}
+CURL_EXTERN const char *curl_easy_strerror(CURLcode){return "cURL (and anything using the web driver) is not supported under WASM";}
+CURL_EXTERN CURLcode curl_easy_getinfo(CURL *curl, CURLINFO info, ...){
+	//if (info==CURLINFO_CONTENT_TYPE)
+		//TODO: set first argument to nullptr
+	return CURLE_OK;
+}
+CURL_EXTERN struct curl_slist *curl_slist_append(struct curl_slist *,
+                                                 const char *){return nullptr;}
+
+CURL_EXTERN void curl_slist_free_all(struct curl_slist *){}

--- a/SplashKitWasm/stubs/ncurses.cpp
+++ b/SplashKitWasm/stubs/ncurses.cpp
@@ -1,0 +1,170 @@
+#include <ncursesw/ncurses.h>
+
+int COLORS = 0;
+WINDOW * stdscr = nullptr;
+
+extern NCURSES_EXPORT(int) use_default_colors (void){return 0;}
+
+extern NCURSES_EXPORT(int) clear (void){return 0;}				/* generated */
+extern NCURSES_EXPORT(int) move (int, int){return 0;}				/* generated */
+extern NCURSES_EXPORT(int) refresh (void){return 0;}				/* generated */
+
+extern NCURSES_EXPORT(int) baudrate (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) beep  (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) can_change_color (void){return false;}			/* implemented */
+extern NCURSES_EXPORT(int) cbreak (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) clearok (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) color_content (NCURSES_COLOR_T,NCURSES_COLOR_T*,NCURSES_COLOR_T*,NCURSES_COLOR_T*){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) copywin (const WINDOW*,WINDOW*,int,int,int,int,int,int,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) curs_set (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) def_prog_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) def_shell_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) delay_output (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) delscreen (SCREEN *){}			/* implemented */
+extern NCURSES_EXPORT(int) delwin (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) derwin (WINDOW *,int,int,int,int){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(int) doupdate (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) dupwin (WINDOW *){return nullptr;}			/* implemented */
+extern NCURSES_EXPORT(int) echo (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(int) endwin (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(char) erasechar (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) filter (void){}				/* implemented */
+extern NCURSES_EXPORT(int) flash (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) flushinp (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) getwin (FILE *){return nullptr;}			/* implemented */
+extern NCURSES_EXPORT(int) halfdelay (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) has_colors (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) has_ic (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(bool) has_il (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) idcok (WINDOW *, bool){}			/* implemented */
+extern NCURSES_EXPORT(int) idlok (WINDOW *, bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(void) immedok (WINDOW *, bool){}			/* implemented */
+extern NCURSES_EXPORT(WINDOW *) initscr (void){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) init_color (NCURSES_COLOR_T,NCURSES_COLOR_T,NCURSES_COLOR_T,NCURSES_COLOR_T){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) init_pair (NCURSES_PAIRS_T,NCURSES_COLOR_T,NCURSES_COLOR_T){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) intrflush (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(bool) isendwin (void){return false;}				/* implemented */
+extern NCURSES_EXPORT(bool) is_linetouched (WINDOW *,int){return false;}		/* implemented */
+extern NCURSES_EXPORT(bool) is_wintouched (WINDOW *){return false;}			/* implemented */
+extern NCURSES_EXPORT(NCURSES_CONST char *) keyname (int){return nullptr;}		/* implemented */
+extern NCURSES_EXPORT(int) keypad (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(char) killchar (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) leaveok (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(char *) longname (void){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) meta (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) mvcur (int,int,int,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) mvderwin (WINDOW *, int, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) mvprintw (int,int, const char *,...)		/* implemented */
+		GCC_PRINTFLIKE(3,4){return 0;}
+extern NCURSES_EXPORT(int) mvscanw (int,int, NCURSES_CONST char *,...)	/* implemented */
+		GCC_SCANFLIKE(3,4){return 0;}
+extern NCURSES_EXPORT(int) mvwin (WINDOW *,int,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) mvwprintw (WINDOW*,int,int, const char *,...)	/* implemented */
+		GCC_PRINTFLIKE(4,5){return 0;}
+extern NCURSES_EXPORT(int) mvwscanw (WINDOW *,int,int, NCURSES_CONST char *,...)	/* implemented */
+		GCC_SCANFLIKE(4,5){return 0;}
+extern NCURSES_EXPORT(int) napms (int){return 0;}					/* implemented */
+extern NCURSES_EXPORT(WINDOW *) newpad (int,int){return nullptr;}		       	/* implemented */
+extern NCURSES_EXPORT(SCREEN *) newterm (NCURSES_CONST char *,FILE *,FILE *){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(WINDOW *) newwin (int,int,int,int){return nullptr;}	       	/* implemented */
+extern NCURSES_EXPORT(int) nl (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(int) nocbreak (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) nodelay (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) noecho (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) nonl (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(void) noqiflush (void){}				/* implemented */
+extern NCURSES_EXPORT(int) noraw (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) notimeout (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) overlay (const WINDOW*,WINDOW *){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) overwrite (const WINDOW*,WINDOW *){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) pair_content (NCURSES_PAIRS_T,NCURSES_COLOR_T*,NCURSES_COLOR_T*){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) pechochar (WINDOW *, const chtype){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) pnoutrefresh (WINDOW*,int,int,int,int,int,int){return 0;}/* implemented */
+extern NCURSES_EXPORT(int) prefresh (WINDOW *,int,int,int,int,int,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) printw (const char *,...)			/* implemented */
+		GCC_PRINTFLIKE(1,2){return 0;}
+extern NCURSES_EXPORT(int) putwin (WINDOW *, FILE *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(void) qiflush (void){}				/* implemented */
+extern NCURSES_EXPORT(int) raw (void){return 0;}					/* implemented */
+extern NCURSES_EXPORT(int) resetty (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) reset_prog_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) reset_shell_mode (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) ripoffline (int, int (*)(WINDOW *, int)){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) savetty (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) scanw (NCURSES_CONST char *,...)		/* implemented */
+		GCC_SCANFLIKE(1,2){return 0;}
+extern NCURSES_EXPORT(int) scr_dump (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scr_init (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scrollok (WINDOW *,bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scr_restore (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) scr_set (const char *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(SCREEN *) set_term (SCREEN *){return nullptr;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_attroff (const chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_attron (const chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_attrset (const chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(attr_t) slk_attr (void){return (attr_t){};}				/* implemented */
+extern NCURSES_EXPORT(int) slk_attr_set (const attr_t,NCURSES_PAIRS_T,void*){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) slk_clear (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_color (NCURSES_PAIRS_T){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_init (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(char *) slk_label (int){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_noutrefresh (void){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) slk_refresh (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_restore (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) slk_set (int,const char *,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) slk_touch (void){return 0;}	      	       		/* implemented */
+extern NCURSES_EXPORT(int) start_color (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(WINDOW *) subpad (WINDOW *, int, int, int, int){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(WINDOW *) subwin (WINDOW *, int, int, int, int){return nullptr;}	/* implemented */
+extern NCURSES_EXPORT(int) syncok (WINDOW *, bool){return 0;}			/* implemented */
+extern NCURSES_EXPORT(chtype) termattrs (void){return 0;}				/* implemented */
+extern NCURSES_EXPORT(char *) termname (void){return nullptr;}				/* implemented */
+extern NCURSES_EXPORT(int) typeahead (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) ungetch (int){return 0;}				/* implemented */
+extern NCURSES_EXPORT(void) use_env (bool){}				/* implemented */
+extern NCURSES_EXPORT(void) use_tioctl (bool){}				/* implemented */
+extern NCURSES_EXPORT(int) vidattr (chtype){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) vidputs (chtype, NCURSES_OUTC){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) vwprintw (WINDOW *, const char *,va_list){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) vwscanw (WINDOW *, NCURSES_CONST char *,va_list){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) waddch (WINDOW *, const chtype){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) waddchnstr (WINDOW *,const chtype *,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) waddnstr (WINDOW *,const char *,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wattr_on (WINDOW *, attr_t, void *){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) wattr_off (WINDOW *, attr_t, void *){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wbkgd (WINDOW *, chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(void) wbkgdset (WINDOW *,chtype){}			/* implemented */
+extern NCURSES_EXPORT(int) wborder (WINDOW *,chtype,chtype,chtype,chtype,chtype,chtype,chtype,chtype){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wchgat (WINDOW *, int, attr_t, NCURSES_PAIRS_T, const void *){return 0;}/* implemented */
+extern NCURSES_EXPORT(int) wclear (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wclrtobot (WINDOW *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wclrtoeol (WINDOW *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wcolor_set (WINDOW*,NCURSES_PAIRS_T,void*){return 0;}		/* implemented */
+extern NCURSES_EXPORT(void) wcursyncup (WINDOW *){}			/* implemented */
+extern NCURSES_EXPORT(int) wdelch (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wechochar (WINDOW *, const chtype){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) werase (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wgetch (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wgetnstr (WINDOW *,char *,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) whline (WINDOW *, chtype, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(chtype) winch (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) winchnstr (WINDOW *, chtype *, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) winnstr (WINDOW *, char *, int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) winsch (WINDOW *, chtype){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) winsdelln (WINDOW *,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) winsnstr (WINDOW *, const char *,int){return 0;}	/* implemented */
+extern NCURSES_EXPORT(int) wmove (WINDOW *,int,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wnoutrefresh (WINDOW *){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wprintw (WINDOW *, const char *,...)		/* implemented */
+		GCC_PRINTFLIKE(2,3){return 0;}
+extern NCURSES_EXPORT(int) wredrawln (WINDOW *,int,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) wrefresh (WINDOW *){return 0;}				/* implemented */
+extern NCURSES_EXPORT(int) wscanw (WINDOW *, NCURSES_CONST char *,...)	/* implemented */
+		GCC_SCANFLIKE(2,3){return 0;}
+extern NCURSES_EXPORT(int) wscrl (WINDOW *,int){return 0;}			/* implemented */
+extern NCURSES_EXPORT(int) wsetscrreg (WINDOW *,int,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(void) wsyncdown (WINDOW *){}			/* implemented */
+extern NCURSES_EXPORT(void) wsyncup (WINDOW *){}				/* implemented */
+extern NCURSES_EXPORT(void) wtimeout (WINDOW *,int){}			/* implemented */
+extern NCURSES_EXPORT(int) wtouchln (WINDOW *,int,int,int){return 0;}		/* implemented */
+extern NCURSES_EXPORT(int) wvline (WINDOW *,chtype,int){return 0;}		/* implemented */

--- a/SplashKitWasm/tools/generateWebIDLBindings.py
+++ b/SplashKitWasm/tools/generateWebIDLBindings.py
@@ -1,0 +1,462 @@
+import json
+import sys
+
+inJSON = open(sys.argv[1], "r")
+outC = open(sys.argv[2], "w")
+outIDL = open(sys.argv[3], "w")
+outJS = open(sys.argv[4], "w")
+print("Reading from "+sys.argv[1]+ ", writing to "+sys.argv[2]+" and "+sys.argv[3]+" and "+sys.argv[4])
+
+api = json.load(inJSON)
+
+def outputC(string):
+    outC.write(string)
+def outputIDL(string):
+    outIDL.write(string)
+def outputJS(string):
+    outJS.write(string)
+
+structs = set()
+function_ptrs = set()
+
+for category_name in api:
+    category = api[category_name]
+    for struct in category["structs"]:
+        structs.add(struct["name"])
+
+    for struct in category["typedefs"]:
+        if struct["is_function_pointer"]:
+            function_ptrs.add(struct["name"])
+            continue
+        else:
+            structs.add(struct["name"])
+
+
+ignore_structs = ["matrix_2d"]
+ignore_functions = [
+"json_read_array",
+"json_set_array",
+"http_post",
+"send_response",
+"lines_from_rectangle",
+"lines_from_triangle",
+"triangles_from",
+"request_headers",
+"request_uri_stubs",
+"split_uri_stubs",
+"message_data_bytes",
+]
+
+def sigisSane(func):
+    for param in func["parameters"]:
+        if func["parameters"][param]["type"] in function_ptrs:
+            return False;
+    if func["name"] in ignore_functions or function_unique_name(func) in ignore_functions:
+        return False
+    return True
+
+# Generate the C++ Wrapper Class
+
+outputC("""
+#include "animations.h"
+#include "audio.h"
+#include "basics.h"
+#include "bundles.h"
+#include "camera.h"
+#include "circle_drawing.h"
+#include "circle_geometry.h"
+#include "clipping.h"
+#include "collisions.h"
+#include "color.h"
+#include "database.h"
+#include "drawing_options.h"
+#include "ellipse_drawing.h"
+#include "geometry.h"
+#include "graphics.h"
+#include "images.h"
+#include "input.h"
+#include "json.h"
+#include "keyboard_input.h"
+#include "line_drawing.h"
+#include "line_geometry.h"
+#include "logging.h"
+#include "matrix_2d.h"
+#include "mouse_input.h"
+#include "music.h"
+#include "networking.h"
+#include "physics.h"
+#include "point_drawing.h"
+#include "point_geometry.h"
+#include "quad_geometry.h"
+#include "random.h"
+#include "rectangle_drawing.h"
+#include "rectangle_geometry.h"
+#include "resources.h"
+#include "sound.h"
+#include "sprites.h"
+#include "terminal.h"
+#include "text.h"
+#include "text_input.h"
+#include "timers.h"
+#include "triangle_drawing.h"
+#include "web_client.h"
+#include "types.h"
+#include "utils.h"
+#include "vector_2d.h"
+#include "web_server.h"
+#include "window_manager.h"
+
+#include <cstring>
+
+using namespace splashkit_lib;
+
+char* outputCStr(std::string str)
+{
+    char* ret = new char[str.size()+1];
+    memcpy( ret, str.c_str(), str.size());
+    ret[str.size()] = '\\0';
+    return ret;
+}
+
+template<typename T>
+std::vector<T> inputArrayToVector(T** items)
+{
+    std::vector<T> out;
+    while(*items!=nullptr)
+    {
+        out.push_back(**items);
+        items++;
+    }
+    return std::move(out);
+}
+std::vector<string> inputArrayToVector(char** items)
+{
+    std::vector<string> out;
+    while(*items!=nullptr)
+    {
+        out.push_back((string)*items);
+        items++;
+    }
+    return std::move(out);
+}
+template<typename T>
+std::vector<T> inputArrayToVector(T* items)
+{
+    std::vector<T> out;
+    while(*items!=nullptr)
+    {
+        out.push_back(*items);
+        items++;
+    }
+    return std::move(out);
+}
+
+template<typename T>
+T** outputVectorToArrayStruct(const std::vector<T> items)
+{
+    T** ret = new T*[items.size()+1];
+    for(std::size_t i = 0; i < items.size(); i++)
+    {
+        ret[i] = new T();
+        *ret[i] = std::move(items[i]);
+    }
+    ret[items.size()] = nullptr;
+    return ret;
+}
+template<typename T>
+T* outputVectorToArray(const std::vector<T> items)
+{
+    T* ret = new T[items.size()+1];
+    for(std::size_t i = 0; i < items.size(); i++)
+    {
+        *ret[i] = items[i];
+    }
+    ret[items.size()] = nullptr;
+    return ret;
+}
+char** outputVectorToArray(const std::vector<string> items)
+{
+    char** ret = new char*[items.size()+1];
+    for(std::size_t i = 0; i < items.size(); i++)
+    {
+        ret[i] = outputCStr(items[i]);
+    }
+    ret[items.size()] = nullptr;
+    return ret;
+}
+
+
+typedef window SKwindow;
+class SplashKitJavascript
+{
+    public:
+""")
+
+def function_unique_name(func):
+    if func["unique_global_name"] != "center_point":
+        return func["unique_global_name"]
+    else:
+        for k in func["parameters"]:
+            if k=="c":
+                return "center_point_circle"
+            if k=="s":
+                return "center_point_sprite"
+    return "ERROR"
+
+
+def generateCTypeAccurate(t):
+    return '%(type)s%(vector)s%(symbol)s' % {
+        'type': sanitizeCTypeInParam(t["type"]),
+        'vector': "<"+t["type_parameter"]+">" if t["is_vector"] else "",
+        'symbol': "*" if t["is_pointer"] else "&" if t["is_reference"] else "",
+    }
+def generateCType(t):
+    is_array = (t["is_vector"] or ("is_array" in t and t["is_array"]))
+    _type = t["type_parameter"] if is_array else t["type"]
+    return '%(type)s%(vector)s%(symbol)s' % {
+        'type': sanitizeCTypeInParam(_type),
+        'vector': ("**" if _type in structs else "*") if is_array else "",
+        'symbol': "*" if t["is_pointer"] else "&" if t["is_reference"] else "",
+    }
+
+def sanitizeCTypeInParam(arg_type):
+    if arg_type == "string":
+        return "char*"
+    if arg_type == "window":
+        return "SKwindow"
+    return arg_type
+def sanitizeCTypeInConvertFront(arg):
+    if arg["type"] == "string":
+        return "(string)"
+    if arg["is_vector"]:
+        return "inputArrayToVector("
+    return ""
+def sanitizeCTypeInConvertBack(arg):
+    if arg["is_vector"]:
+        return ")"
+    return ""
+
+def sanitizeCTypeOutConvertFront(arg):
+    if arg["type"] == "string":
+        return "outputCStr("
+    if arg["is_vector"]:
+        if arg["type_parameter"] in structs:
+            return "outputVectorToArrayStruct("
+        else:
+            return "outputVectorToArray("
+    return ""
+def sanitizeCTypeOutConvertBack(arg):
+    if arg["type"] == "string":
+        return ")"
+    if arg["is_vector"]:
+        return ")"
+    return ""
+
+def generateCArgList(arglist):
+    args = ""
+    for argname in func["parameters"]:
+        arg = func["parameters"][argname]
+
+        args += '%(type)s %(name)s,' % {
+            'type': generateCType(arg),
+            'name': argname
+        }
+
+    return args[:-1]
+
+def generateCCallList(arglist):
+    args = ""
+    for argname in func["parameters"]:
+        arg = func["parameters"][argname]
+
+        args += '%(cast)s%(name)s%(castend)s,' % {
+            'cast': sanitizeCTypeInConvertFront(arg),
+            'castend': sanitizeCTypeInConvertBack(arg),
+            'name': argname
+        }
+
+    return args[:-1]
+
+def generateCSig(func):
+    return '%(return_type)s %(name)s(%(args)s)' % {
+        'return_type': generateCType(func["return"]),
+        'name': function_unique_name(func),
+        'args': generateCArgList(func["parameters"])
+    }
+
+def generateCCall(func):
+    return '%(convertFront)ssplashkit_lib::%(name)s(%(args)s)%(convertBack)s' % {
+        #'return_type': generateCType(func["return"]),
+        'name': func["name"],
+        'args': generateCCallList(func["parameters"]),
+        'convertFront': sanitizeCTypeOutConvertFront(func["return"]),
+        'convertBack': sanitizeCTypeOutConvertBack(func["return"])
+    }
+
+
+for category_name in api:
+    category = api[category_name]
+    for func in category["functions"]:
+        if not sigisSane(func):
+            continue
+        outputC("        "+generateCSig(func))
+        outputC("{\n")
+        outputC("            return "+generateCCall(func))
+        outputC(";\n        }\n\n")
+
+outputC("""
+};
+
+
+#include "SplashKitWasmGlue.cpp"
+""");
+
+
+
+# Generate the WebIDL Bindings
+
+
+def sanitizeIDLTypeInParam(arg_type):
+    if arg_type == "string":
+        return "DOMString"
+    if arg_type == "bool":
+        return "boolean"
+    if arg_type == "int":
+        return "long"
+    if arg_type == "unsigned int":
+        return "unsigned long"
+    if arg_type == "int8_t":
+        return "byte"
+    if arg_type == "char":
+        return "byte"
+    if arg_type == "window":
+        return "SKwindow"
+    return arg_type
+
+def generateIDLType(t, force_ref, attribute=False):
+    if t["type"] in structs:
+        symbol = "" if t["is_pointer"] else "[Ref]" if (t["is_reference"] or force_ref) else "[Value]"
+    else:
+        symbol =  "[ERROR Pointers to base types unsuported]" if t["is_pointer"] else "[Ref]" if (t["is_reference"] and not t["type"]=="string" and False) else ""
+
+    return '%(symbol)s %(attribute)s%(type)s%(array)s' % {
+        'type': (sanitizeIDLTypeInParam(t["type_parameter"])) if t["is_vector"] else sanitizeIDLTypeInParam(t["type"]),
+        'array': "[]" if (t["is_vector"] or ("is_array" in t and t["is_array"])) else "",
+        'symbol': symbol,
+        'attribute': "attribute " if attribute else "",
+    }
+
+def generateIDLArgList(arglist):
+    args = ""
+    for argname in func["parameters"]:
+        arg = func["parameters"][argname]
+
+        args += '%(type)s %(name)s,' % {
+            'type': generateIDLType(arg, True),
+            'name': argname
+        }
+
+    return args[:-1]
+
+generate_sig_names = set()
+def generateIDLSig(func):
+    if function_unique_name(func) in generate_sig_names:
+        print("Oh oh: ", function_unique_name(func))
+    generate_sig_names.add(function_unique_name(func))
+    return '%(return_type)s %(name)s(%(args)s)' % {
+        'return_type': generateIDLType(func["return"], False),
+        'name': function_unique_name(func),
+        'args': generateIDLArgList(func["parameters"])
+    }
+
+def generateIDLStructFields(fieldlist):
+    fields = ""
+    for field_name in fieldlist:
+        field = fieldlist[field_name]
+        if field["type"]=="void":#TODO: Fix
+            continue
+        fields += '    %(type)s %(name)s;\n' % {
+            'type': generateIDLType(field, False, attribute=True),
+            'name': field_name
+        }
+    return fields
+
+def sanitizeStructName(name):
+    if name=="window":
+        return "SKwindow"
+    return name
+
+def generateIDLStruct(struct):
+    return "interface %(name)s {\n    void %(name)s();\n%(fields)s};\n" % {
+        'name': sanitizeStructName(struct["name"]),
+        'fields': generateIDLStructFields(struct["fields"]) if ("fields" in struct and struct["name"] not in ignore_structs) else ""
+    }
+
+def generateIDLEnum(enum):
+    elist = ""
+    for const in enum["constants"]:
+        elist += "    \""+const+"\",\n"
+    return "enum %(name)s {\n%(enums)s};\n" % {
+        'name': enum["name"],
+        'enums': elist
+    }
+
+
+
+for category_name in api:
+    category = api[category_name]
+    for struct in category["structs"]:
+        outputIDL(generateIDLStruct(struct))
+
+    for struct in category["typedefs"]:
+        if struct["is_function_pointer"]:
+            continue
+        outputIDL(generateIDLStruct(struct))
+
+    for enum in category["enums"]:
+        outputIDL(generateIDLEnum(enum))
+
+
+outputIDL("""interface SplashKitJavascript {
+    void SplashKitJavascript();
+""")
+for category_name in api:
+    category = api[category_name]
+    for func in category["functions"]:
+        if sigisSane(func):
+            outputIDL("    "+generateIDLSig(func)+";\n")
+outputIDL("""};""")
+
+
+
+# Generate code to bind the functions from the module into the global scope
+outputJS("""let SK;
+
+""")
+for category_name in api:
+    category = api[category_name]
+    for enum in category["enums"]:
+        for const in enum["constants"]:
+            outputJS("let "+const+";\n")
+    outputJS("\n")
+    for func in category["functions"]:
+        if sigisSane(func):
+            outputJS("let "+function_unique_name(func)+";\n")
+    outputJS("\n\n")
+
+outputJS("""
+function initializeGlobalSplashKitScope(){
+    SK = new Module.SplashKitJavascript();
+
+""")
+for category_name in api:
+    category = api[category_name]
+    for enum in category["enums"]:
+        for const in enum["constants"]:
+            outputJS("    "+const+" = Module."+const+";\n")
+    outputJS("\n")
+    for func in category["functions"]:
+        if sigisSane(func):
+            outputJS("    "+function_unique_name(func)+" = SK."+function_unique_name(func)+";\n")
+    outputJS("\n\n")
+outputJS("""};""")

--- a/SplashKitWasm/tools/generateWebIDLBindings.py
+++ b/SplashKitWasm/tools/generateWebIDLBindings.py
@@ -12,7 +12,32 @@ api = json.load(inJSON)
 def outputC(string):
     outC.write(string)
 def outputIDL(string):
+    replacements = [
+        ("_window_data", "window"),
+        ("sk_font_data","font"),
+        ("sk_display","display"),
+        ("_bitmap_data","bitmap"),
+        ("_animation_script_data","animation_script"),
+        ("_animation_data","animation"),
+        ("_timer_data","timer"),
+        ("_sprite_data","sprite"),
+        ("sk_server_data","server_socket"),
+        ("sk_message","message"),
+        ("sk_connection_data","connection"),
+        ("sk_web_server","web_server"),
+        ("sk_http_request","http_request"),
+        ("sk_http_response","http_response"),
+        ("sk_json","json"),
+        ("sk_query_result","query_result"),
+        ("sk_database","database"),
+        ("_sound_data","sound_effect"),
+        ("_music_data","music"),
+    ]
+    for p,t in replacements:
+        string = string.replace("[Ref] "+t,p);
+        string = string.replace("[Value] "+t,p);
     outIDL.write(string)
+
 def outputJS(string):
     outJS.write(string)
 
@@ -107,6 +132,17 @@ outputC("""
 #include "window_manager.h"
 
 #include <cstring>
+
+#define sprite_data _sprite_data
+#define bitmap_data _bitmap_data
+#define sound_data _sound_data
+#define sound_effect_data _sound_effect_data
+#define animation_data _animation_data
+#define animation_script_data _animation_script_data
+#define window_data _window_data
+#define timer_data _timer_data
+#define music_data _music_data
+
 
 using namespace splashkit_lib;
 
@@ -307,7 +343,6 @@ for category_name in api:
 outputC("""
 };
 
-
 #include "SplashKitWasmGlue.cpp"
 """);
 
@@ -417,7 +452,47 @@ for category_name in api:
         outputIDL(generateIDLEnum(enum))
 
 
-outputIDL("""interface SplashKitJavascript {
+outputIDL("""
+interface _sprite_data {
+};
+interface _bitmap_data {
+};
+interface _sound_data {
+};
+interface _animation_data {
+};
+interface _animation_script_data {
+};
+interface _window_data {
+};
+interface sk_font_data {
+};
+interface sk_display {
+};
+interface _timer_data {
+};
+interface sk_server_data {
+};
+interface sk_message {
+};
+interface sk_connection_data {
+};
+interface sk_web_server {
+};
+interface sk_http_request {
+};
+interface sk_http_response {
+};
+interface sk_json {
+};
+interface sk_query_result {
+};
+interface sk_database {
+};
+interface _music_data {
+};
+
+interface SplashKitJavascript {
     void SplashKitJavascript();
 """)
 for category_name in api:


### PR DESCRIPTION
# Description

This pull request makes the SplashKit WebAssembly library port compilable within this repo - this makes it easier and safer to continue developing the port without having to touch the splashkit-core repository directly.

List of changes:
 - add splashkit-core as a submodule
 - include stubs for curl and ncurses
 - include modified CMakeLists for Emscripten build
 - include old IDLBindings generator
   - include stop-gap fix for the bindings 'value returns are singletons' issue
 - brief update to the readme with working instructions

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- The repository has been downloaded cleanly, and the instructions in the readme followed, with a successful build of the SplashKit library, and successful setup and running of the online IDE.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request