### PR TITLE
refactor: load SplashKitBackend.wasm/js manually, and add download progress/fail events

### DIFF
--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -19,11 +19,6 @@
 
 <body class="bg-dark" style="position:relative;width:100%;height:100vh;margin:0;padding:0;display:flex;">
             <div class="col d-flex flex-column bg-dark justify-content-center flex-grow-1" >
-                <figure style="" id="spinner"><div></div><center style="margin-top:0.5em"><strong>emscripten</strong></center></figure>
-                <div id="status">Downloading...</div>
-                <div>
-                  <progress value="0" max="100" id="progress" hidden=1></progress>
-                </div>
                 <div class="row m-3">
                   <canvas id="canvas" style="vertical-align:center; max-width: 100%; width:inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
                 </div>
@@ -33,9 +28,9 @@
             </div>
 </body>
 <script src="splashkit/SplashKitGlobalAPI.js"></script>
+<script src="moduleEventTarget.js"></script>
 <script src="loadsplashkit.js"></script>
 <script src="fsevents.js"></script>
-<script src="splashkit/SplashKitBackendWASM.js"></script>
 <script src="executionEnvironment_CodeProcessor.js"></script>
 <script src="executionEnvironment_Internal.js"></script>
 </html>

--- a/Browser_IDE/moduleEventTarget.js
+++ b/Browser_IDE/moduleEventTarget.js
@@ -1,0 +1,20 @@
+"use strict";
+
+// A global event hook for module loading events
+let moduleEvents = new EventTarget();
+
+// Events:
+// onRuntimeInitialized
+
+// onDownloadProgress:
+//     info             (directly from XMLHttpRequest)
+//     downloadName
+//     downloadIndex    (1 indexed)
+//     downloadCount
+//     downloadProgress (betwen 0 and 1)
+
+// onDownloadFail:
+//     info             (directly from XMLHttpRequest)
+//     downloadName
+//     downloadIndex    (1 indexed)
+//     downloadCount


### PR DESCRIPTION
# Description

This pull request changes how we load the SplashKit library, so that we may add a loading bar in the future.

The existing Emscripten 'monitorRunDependencies' does not provide download progress, and since we only have a single 'dependency', would only output either 0 or 1 - not useful for a loading bar. 

This pull request makes it so that we manually load the WebAssembly file, and the Emscripten generated JavaScript file, so that we can provide proper download progress events.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- The new loading scheme has been tested on Firefox desktop and mobile, and has been timed to show it has no speed impact.
- The events have been tested by hooking into them and printing the download progress to the console.

## Testing Checklist:

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [ ] Tested in latest Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request