### PR TITLE
Fixed rearranging of visual nodes in the file tree view

### DIFF
--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -24,7 +24,7 @@ myTreeView.addEventListener("folderUploadRequest", function(e){
 
 // Attach to file system callbacks within the Execution Environment
 executionEnviroment.addEventListener('onMovePath', function(e) {
-    myTreeView.moveNode(e.oldPath, e.newPath, -1, "transient");
+    myTreeView.moveNode(e.oldPath, e.newPath, "transient");
 });
 
 executionEnviroment.addEventListener('onMakeDirectory', function(e) {
@@ -42,7 +42,7 @@ executionEnviroment.addEventListener('onOpenFile', function(e) {
 // Attach to file system callbacks within the IDBStoredProject
 storedProject.addEventListener('onMovePath', function(e) {
     //TODO: Get moving to specific index working again - ideally make it persistent as well
-    myTreeView.moveNode(e.oldPath, e.newPath, -1, "persistent");
+    myTreeView.moveNode(e.oldPath, e.newPath, "persistent");
 });
 
 storedProject.addEventListener('onMakeDirectory', function(e) {

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -8,6 +8,7 @@ myTreeView.addEventListener("nodeMoveRequest", function(e){
         executionEnviroment.rename(e.oldPath, e.newPath);
     if (e.FS.includes("persistent"))
         storedProject.access((project)=>project.rename(e.oldPath, e.newPath));
+	 e.accept();
 });
 
 myTreeView.addEventListener("nodeDoubleClick", function(e){

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -8,7 +8,7 @@ myTreeView.addEventListener("nodeMoveRequest", function(e){
         executionEnviroment.rename(e.oldPath, e.newPath);
     if (e.FS.includes("persistent"))
         storedProject.access((project)=>project.rename(e.oldPath, e.newPath));
-	 e.accept();
+    e.accept();
 });
 
 myTreeView.addEventListener("nodeDoubleClick", function(e){

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -100,7 +100,7 @@ class TreeView extends EventTarget{
 
     // Public Facing Methods
     // note: None of these manual changes to the tree call any callbacks - this stops any recursion happening
-    moveNode(oldPath, newPath, index = -1, FS){
+    moveNode(oldPath, newPath, FS){
         let treeView = this;
         if (oldPath == newPath)
             return;


### PR DESCRIPTION
https://trello.com/c/vyMXy00U/363-make-moving-nodes-in-the-tree-view-retain-their-index-again

Previously, dragging a visual node in the file tree to specific position in a directory would only have the effect of that node being placed at the end of that directory.

All that was missing was that the filesystem event handler was neglecting to call the callback supplied in the FS node move request event generated by the tree view. Now, after the filesystem has moved the filesystem node, it will run the callback so that the visual node can be moved to the position it was dragged to in the UI.

TreeView.moveNode is only involved when the filesystem needs to notify the tree view of a change in the filesystem structure. Since the filesystem has no notion of nodes being ordered, it cannot supply any index to move the visual node to anyway, so the index parameter has been removed. 

![image](https://github.com/thoth-tech/SplashkitOnline/assets/129343526/eda2396d-21bc-45c8-ada9-2fb524f77e95)


Before fix:
![broken-treeview-indices](https://github.com/thoth-tech/SplashkitOnline/assets/129343526/8d1a4248-82e3-4055-a80c-1f83d0bb7909)


After fix:
![fixed-treeview-indices](https://github.com/thoth-tech/SplashkitOnline/assets/129343526/0b5d4c38-7cc9-4cc3-8154-0926fbb1e89a)
