### PR TITLE
Added delete button to file tree nodes

### DIFF
--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -610,3 +610,29 @@ storedProject.addEventListener("timeConflict", async function() {
     if (!userHasIgnoredProjectConflict)
         projectConflictModal.show();
 });
+
+
+window.addEventListener("needConfirmation", async function(ev){
+    let confirmLabel = ev.confirmLabel || "Confirm";
+    let cancelLabel = ev.cancelLabel || "cancel";
+    
+    let confirmationModal = createModal(
+        "confirmationModal",
+        ev.shortMessage,
+        ev.longMessage,
+        {label: cancelLabel, callback: ()=>{
+            ev.oncancel();
+            confirmationModal.hide();
+        }},
+        {label: confirmLabel, callback: ()=>{
+            ev.onconfirm();
+            confirmationModal.hide();
+        }}
+    );
+    confirmationModal.show();
+
+    let confirmationModalEl = document.getElementById("confirmationModal");
+    confirmationModalEl.addEventListener("hidden.bs.modal", function(innerEv){
+        confirmationModalEl.dispose();
+    });
+});

--- a/Browser_IDE/executionEnvironment.js
+++ b/Browser_IDE/executionEnvironment.js
@@ -194,7 +194,12 @@ class ExecutionEnvironment extends EventTarget{
             newPath: newPath,
         }, "*");
     }
-
+    unlink(path){
+        this.iFrame.contentWindow.postMessage({
+            type: "unlink",
+            path: path
+        }, "*");
+    }
 
 
 

--- a/Browser_IDE/executionEnvironment.js
+++ b/Browser_IDE/executionEnvironment.js
@@ -200,7 +200,13 @@ class ExecutionEnvironment extends EventTarget{
             path: path
         }, "*");
     }
-
+    rmdir(path, recursive = false){
+        this.iFrame.contentWindow.postMessage({
+            type: "rmdir",
+            path: path,
+            recursive: recursive
+        }, "*");
+    }
 
 
 

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -445,6 +445,9 @@ window.addEventListener('message', function(m){
                 for(let entry of entries){
                     if(entry == "." || entry == "..")
                         continue;
+					// All directories contain a reference to themself
+					// and to their parent directory. Ignore them.
+
                     let entryPath = p + "/" + entry;
                     let entryStat = FS.stat(entryPath, false);
 
@@ -459,6 +462,8 @@ window.addEventListener('message', function(m){
             }
             deleteContentsRecursive(m.data.path);
             FS.rmdir(m.data.path);
+			// FS.rmdir expects the directory to be empty
+			// and will throw an error if it is not.
         } else {
             FS.rmdir(m.data.path);
         }

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -434,35 +434,35 @@ window.addEventListener('message', function(m){
         FS.rename(m.data.oldPath,m.data.newPath);
     }
 
-	if (m.data.type == "unlink"){
-		FS.unlink(m.data.path);
-	}
-	
-	if (m.data.type == "rmdir"){
-		if(m.data.recursive){
-			let deleteContentsRecursive = function(p){
-				let entries = FS.readdir(p);
-				for(let entry of entries){
-					if(entry == "." || entry == "..")
-						continue;
-					let entryPath = p + "/" + entry;
-					let entryStat = FS.stat(entryPath, false);
+    if (m.data.type == "unlink"){
+        FS.unlink(m.data.path);
+    }
+    
+    if (m.data.type == "rmdir"){
+        if(m.data.recursive){
+            let deleteContentsRecursive = function(p){
+                let entries = FS.readdir(p);
+                for(let entry of entries){
+                    if(entry == "." || entry == "..")
+                        continue;
+                    let entryPath = p + "/" + entry;
+                    let entryStat = FS.stat(entryPath, false);
 
-					if(FS.isDir(entryStat.mode)){
-						deleteContentsRecursive(entryPath);
-						FS.rmdir(entryPath);
-					} else if(FS.isFile(entryStat.mode)){
-						FS.unlink(entryPath);
-					}
-					
-				}
-			}
-			deleteContentsRecursive(m.data.path);
-			FS.rmdir(m.data.path);
-		} else {
-			FS.rmdir(m.data.path);
-		}
-	}
+                    if(FS.isDir(entryStat.mode)){
+                        deleteContentsRecursive(entryPath);
+                        FS.rmdir(entryPath);
+                    } else if(FS.isFile(entryStat.mode)){
+                        FS.unlink(entryPath);
+                    }
+                    
+                }
+            }
+            deleteContentsRecursive(m.data.path);
+            FS.rmdir(m.data.path);
+        } else {
+            FS.rmdir(m.data.path);
+        }
+    }
 
 }, false);
 

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -437,6 +437,8 @@ window.addEventListener('message', function(m){
 	if (m.data.type == "unlink"){
 		FS.unlink(m.data.path);
 	}
+	
+	// TODO: handle rmdir
 
 }, false);
 

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -434,6 +434,10 @@ window.addEventListener('message', function(m){
         FS.rename(m.data.oldPath,m.data.newPath);
     }
 
+	if (m.data.type == "unlink"){
+		FS.unlink(m.data.path);
+	}
+
 }, false);
 
 // FS Event Forwarding

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -438,7 +438,31 @@ window.addEventListener('message', function(m){
 		FS.unlink(m.data.path);
 	}
 	
-	// TODO: handle rmdir
+	if (m.data.type == "rmdir"){
+		if(m.data.recursive){
+			let deleteContentsRecursive = function(p){
+				let entries = FS.readdir(p);
+				for(let entry of entries){
+					if(entry == "." || entry == "..")
+						continue;
+					let entryPath = p + "/" + entry;
+					let entryStat = FS.stat(entryPath, false);
+
+					if(FS.isDir(entryStat.mode)){
+						deleteContentsRecursive(entryPath);
+						FS.rmdir(entryPath);
+					} else if(FS.isFile(entryStat.mode)){
+						FS.unlink(entryPath);
+					}
+					
+				}
+			}
+			deleteContentsRecursive(m.data.path);
+			FS.rmdir(m.data.path);
+		} else {
+			FS.rmdir(m.data.path);
+		}
+	}
 
 }, false);
 

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -445,8 +445,8 @@ window.addEventListener('message', function(m){
                 for(let entry of entries){
                     if(entry == "." || entry == "..")
                         continue;
-					// All directories contain a reference to themself
-					// and to their parent directory. Ignore them.
+                    // All directories contain a reference to themself
+                    // and to their parent directory. Ignore them.
 
                     let entryPath = p + "/" + entry;
                     let entryStat = FS.stat(entryPath, false);
@@ -462,8 +462,8 @@ window.addEventListener('message', function(m){
             }
             deleteContentsRecursive(m.data.path);
             FS.rmdir(m.data.path);
-			// FS.rmdir expects the directory to be empty
-			// and will throw an error if it is not.
+            // FS.rmdir expects the directory to be empty
+            // and will throw an error if it is not.
         } else {
             FS.rmdir(m.data.path);
         }

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -21,6 +21,8 @@ myTreeView.addEventListener("folderUploadRequest", function(e){
 });
 
 myTreeView.addEventListener("fileDeleteRequest", function(e){
+	if (e.FS.includes("transient"))
+        executionEnviroment.unlink(e.path);
 	if (e.FS.includes("persistent"))
         storedProject.access((project)=>project.unlink(e.path));
 });

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -21,16 +21,16 @@ myTreeView.addEventListener("folderUploadRequest", function(e){
 });
 
 myTreeView.addEventListener("fileDeleteRequest", function(e){
-	if (e.FS.includes("transient"))
+    if (e.FS.includes("transient"))
         executionEnviroment.unlink(e.path);
-	if (e.FS.includes("persistent"))
+    if (e.FS.includes("persistent"))
         storedProject.access((project)=>project.unlink(e.path));
 });
 
 myTreeView.addEventListener("folderDeleteRequest", function(e){
-	if (e.FS.includes("transient"))
+    if (e.FS.includes("transient"))
         executionEnviroment.rmdir(e.path, true);
-	if (e.FS.includes("persistent"))
+    if (e.FS.includes("persistent"))
         storedProject.access((project)=>project.rmdir(e.path, true));
 });
 

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -28,6 +28,8 @@ myTreeView.addEventListener("fileDeleteRequest", function(e){
 });
 
 myTreeView.addEventListener("folderDeleteRequest", function(e){
+	if (e.FS.includes("transient"))
+        executionEnviroment.rmdir(e.path, true);
 	if (e.FS.includes("persistent"))
         storedProject.access((project)=>project.rmdir(e.path, true));
 });

--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -20,6 +20,15 @@ myTreeView.addEventListener("folderUploadRequest", function(e){
     document.getElementById("fileuploader").click();
 });
 
+myTreeView.addEventListener("fileDeleteRequest", function(e){
+	if (e.FS.includes("persistent"))
+        storedProject.access((project)=>project.unlink(e.path));
+});
+
+myTreeView.addEventListener("folderDeleteRequest", function(e){
+	if (e.FS.includes("persistent"))
+        storedProject.access((project)=>project.rmdir(e.path, true));
+});
 
 // Attach to file system callbacks within the Execution Environment
 executionEnviroment.addEventListener('onMovePath', function(e) {

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -337,6 +337,9 @@ class TreeView extends EventTarget{
         let dir_node_upload_file_button = document.createElement("button");
         dir_node_upload_file_button.classList.add("bi-plus-circle", "node-button");
 
+        let dir_node_delete_button = document.createElement("button");
+        dir_node_delete_button.classList.add("bi-dash-circle", "node-button");
+
         let dir_node_label_text = document.createTextNode(label==""?"/":label);
 
         let dir_node_contents = document.createElement("div");
@@ -346,6 +349,7 @@ class TreeView extends EventTarget{
         dir_node_label_text_div.appendChild(dir_node_label_text);
         dir_node_label.appendChild(dir_node_label_text_div);
         dir_node_label.appendChild(dir_node_upload_file_button);
+        dir_node_label.appendChild(dir_node_delete_button);
         dir_node.appendChild(dir_node_label);
         dir_node.appendChild(dir_node_contents);
 
@@ -389,6 +393,14 @@ class TreeView extends EventTarget{
             e.stopPropagation();
         });
 
+        dir_node_delete_button.addEventListener("click", async function(e){
+            let ev = new Event("folderDeleteRequest");
+            ev.treeView = boundTree;
+            ev.path = boundTree.getFullPath(dir_node);
+            ev.FS = boundTree.nodeGetFS(dir_node);
+            boundTree.dispatchEvent(ev);
+            e.stopPropagation();
+        });
 
         this.initFileNodeCallbacks(dir_node);
         return dir_node;
@@ -410,10 +422,14 @@ class TreeView extends EventTarget{
         let file_node_label_text_div = document.createElement("div");
         file_node_label_text_div.classList.add("node-label-text");
 
+        let file_node_delete_button = document.createElement("button");
+        file_node_delete_button.classList.add("bi-dash-circle", "node-button");
+
         let file_node_label_text = document.createTextNode(label);
 
         file_node_label_text_div.appendChild(file_node_label_text);
         file_node_label.appendChild(file_node_label_text_div);
+        file_node_label.appendChild(file_node_delete_button);
 
         file_node_label.addEventListener("click", async function (e) {
             e.stopPropagation();
@@ -427,6 +443,15 @@ class TreeView extends EventTarget{
             ev.path = boundTree.getFullPath(file_node_label);
             ev.FS = boundTree.nodeGetFS(file_node_label);
             boundTree.dispatchEvent(ev);
+        });
+
+        file_node_delete_button.addEventListener("click", async function(e){
+            let ev = new Event("fileDeleteRequest");
+            ev.treeView = boundTree;
+            ev.path = boundTree.getFullPath(file_node_label);
+            ev.FS = boundTree.nodeGetFS(file_node_label);
+            boundTree.dispatchEvent(ev);
+            e.stopPropagation();
         });
 
         this.initFileNodeCallbacks(file_node_label);

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -340,8 +340,9 @@ class TreeView extends EventTarget{
         // The root directory should not be deleteable.
         // Seems hack-y. Is "" a valid file/dir name?
         // Maybe it would be better for the caller to just remove the button afterwards. 
+        let dir_node_delete_button = undefined;
         if(label != ""){
-            let dir_node_delete_button = document.createElement("button");
+            dir_node_delete_button = document.createElement("button");
             dir_node_delete_button.classList.add("bi-dash-circle", "node-button");
         }
 

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -335,7 +335,7 @@ class TreeView extends EventTarget{
         dir_node_label_text_div.classList.add("node-label-text");
 
         let dir_node_upload_file_button = document.createElement("button");
-        dir_node_upload_file_button.classList.add("bi-plus-circle", "node-button");
+        dir_node_upload_file_button.classList.add("bi-file-earmark-arrow-up", "node-button");
 
         // The root directory should not be deleteable.
         // Seems hack-y. Is "" a valid file/dir name?
@@ -343,7 +343,7 @@ class TreeView extends EventTarget{
         let dir_node_delete_button = undefined;
         if(label != ""){
             dir_node_delete_button = document.createElement("button");
-            dir_node_delete_button.classList.add("bi-dash-circle", "node-button");
+            dir_node_delete_button.classList.add("bi-trash", "node-button");
         }
 
         let dir_node_label_text = document.createTextNode(label==""?"/":label);
@@ -435,7 +435,7 @@ class TreeView extends EventTarget{
         file_node_label_text_div.classList.add("node-label-text");
 
         let file_node_delete_button = document.createElement("button");
-        file_node_delete_button.classList.add("bi-dash-circle", "node-button");
+        file_node_delete_button.classList.add("bi-trash", "node-button");
 
         let file_node_label_text = document.createTextNode(label);
 

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -337,8 +337,13 @@ class TreeView extends EventTarget{
         let dir_node_upload_file_button = document.createElement("button");
         dir_node_upload_file_button.classList.add("bi-plus-circle", "node-button");
 
-        let dir_node_delete_button = document.createElement("button");
-        dir_node_delete_button.classList.add("bi-dash-circle", "node-button");
+        // The root directory should not be deleteable.
+        // Seems hack-y. Is "" a valid file/dir name?
+        // Maybe it would be better for the caller to just remove the button afterwards. 
+        if(label != ""){
+            let dir_node_delete_button = document.createElement("button");
+            dir_node_delete_button.classList.add("bi-dash-circle", "node-button");
+        }
 
         let dir_node_label_text = document.createTextNode(label==""?"/":label);
 
@@ -349,7 +354,11 @@ class TreeView extends EventTarget{
         dir_node_label_text_div.appendChild(dir_node_label_text);
         dir_node_label.appendChild(dir_node_label_text_div);
         dir_node_label.appendChild(dir_node_upload_file_button);
-        dir_node_label.appendChild(dir_node_delete_button);
+
+        if(label != ""){
+            dir_node_label.appendChild(dir_node_delete_button);
+        }
+
         dir_node.appendChild(dir_node_label);
         dir_node.appendChild(dir_node_contents);
 
@@ -393,14 +402,16 @@ class TreeView extends EventTarget{
             e.stopPropagation();
         });
 
-        dir_node_delete_button.addEventListener("click", async function(e){
-            let ev = new Event("folderDeleteRequest");
-            ev.treeView = boundTree;
-            ev.path = boundTree.getFullPath(dir_node);
-            ev.FS = boundTree.nodeGetFS(dir_node);
-            boundTree.dispatchEvent(ev);
-            e.stopPropagation();
-        });
+        if(label != ""){
+            dir_node_delete_button.addEventListener("click", async function(e){
+                let ev = new Event("folderDeleteRequest");
+                ev.treeView = boundTree;
+                ev.path = boundTree.getFullPath(dir_node);
+                ev.FS = boundTree.nodeGetFS(dir_node);
+                boundTree.dispatchEvent(ev);
+                e.stopPropagation();
+            });
+        }
 
         this.initFileNodeCallbacks(dir_node);
         return dir_node;

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -405,11 +405,19 @@ class TreeView extends EventTarget{
 
         if(label != ""){
             dir_node_delete_button.addEventListener("click", async function(e){
-                let ev = new Event("folderDeleteRequest");
-                ev.treeView = boundTree;
-                ev.path = boundTree.getFullPath(dir_node);
-                ev.FS = boundTree.nodeGetFS(dir_node);
-                boundTree.dispatchEvent(ev);
+                let confirmEv = new Event("needConfirmation");
+                confirmEv.shortMessage = "Confirm delete";
+                confirmEv.longMessage = "Are you sure you want to delete this?";
+                confirmEv.confirmLabel = "Delete";
+                confirmEv.oncancel = ()=>{};
+                confirmEv.onconfirm = ()=>{
+                    let deleteEv = new Event("folderDeleteRequest");
+                    deleteEv.treeView = boundTree;
+                    deleteEv.path = boundTree.getFullPath(dir_node);
+                    deleteEv.FS = boundTree.nodeGetFS(dir_node);
+                    boundTree.dispatchEvent(deleteEv);
+                };
+                window.dispatchEvent(confirmEv);
                 e.stopPropagation();
             });
         }
@@ -458,11 +466,19 @@ class TreeView extends EventTarget{
         });
 
         file_node_delete_button.addEventListener("click", async function(e){
-            let ev = new Event("fileDeleteRequest");
-            ev.treeView = boundTree;
-            ev.path = boundTree.getFullPath(file_node_label);
-            ev.FS = boundTree.nodeGetFS(file_node_label);
-            boundTree.dispatchEvent(ev);
+            let confirmEv = new Event("needConfirmation");
+            confirmEv.shortMessage = "Confirm delete";
+            confirmEv.longMessage = "Are you sure you want to delete this?";
+            confirmEv.confirmLabel = "Delete";
+            confirmEv.oncancel = ()=>{};
+            confirmEv.onconfirm = ()=>{
+                let deleteEv = new Event("fileDeleteRequest");
+                deleteEv.treeView = boundTree;
+                deleteEv.path = boundTree.getFullPath(file_node_label);
+                deleteEv.FS = boundTree.nodeGetFS(file_node_label);
+                boundTree.dispatchEvent(deleteEv);
+            };
+            window.dispatchEvent(confirmEv);
             e.stopPropagation();
         });
 


### PR DESCRIPTION
# Description

A delete button has been added to files and folders in the tree view. Upon clicking it, the node will be deleted. In the case of a folder, its contents will be recursively deleted. This deletion occurs in both the IndexedDB filesystem and the execution environment filesystem.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

(The documentation for ExecutionEnvironment and TreeView will need to be updated.)

## How Has This Been Tested?

The cases I tested were:
- Deleting a single persistent file.
- Deleting a single transient file.
- Deleting an empty persistent folder.
- Deleting an empty transient folder.
- Deleting a persistent folder with persistent contents.

In each of the persistent cases, I tested whether the deletion persisted after reloading the page.

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
