### PR TITLE
Make `read_line()` work better

### DIFF
--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -21,6 +21,7 @@
 		</div>
 		<div class="sk-contents">
 			<textarea id="output" class="sk-contents sk-contents-darker" readonly style="border:0; padding-left:1em; resize: none;"></textarea>
+			<input type="text" id="user-input" class="sk-input" style="width:100%; padding:0.5em; margin-top:0.5em;" placeholder="Type command here and press Enter..." onkeydown="handleUserInput(event)">
 		</div>
 	</div>
 </body>
@@ -30,4 +31,5 @@
 <script src="fsevents.js"></script>
 <script src="executionEnvironment_CodeProcessor.js"></script>
 <script src="executionEnvironment_Internal.js"></script>
+<script src="handleUserInput.js"></script>
 </html>

--- a/Browser_IDE/executionEnvironment_CodeProcessor.js
+++ b/Browser_IDE/executionEnvironment_CodeProcessor.js
@@ -234,6 +234,7 @@ let findGlobalDeclarationsTransform__awaitables = new Set();
 findGlobalDeclarationsTransform__awaitables.add("refresh_screen");
 findGlobalDeclarationsTransform__awaitables.add("refresh_screen_with_target_fps");
 findGlobalDeclarationsTransform__awaitables.add("delay");
+findGlobalDeclarationsTransform__awaitables.add("read_line");
 
 function findGlobalDeclarationsTransform(babel){
     return{

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -51,6 +51,14 @@ moduleEvents.addEventListener("onRuntimeInitialized", function() {
         return new Promise((re) => setTimeout(re, milliseconds));
     }
 
+    window.userInputResolve = null;
+    window.read_line = function() {
+        console.log("read_line is waiting for user input...");
+        return new Promise(resolve => {
+            window.userInputResolve = resolve;
+        });
+    };
+
     // In case function overloads are disabled
     if (window.refresh_screen_with_target_fps != undefined){
         let original_refresh_screen_with_target_fps = refresh_screen_with_target_fps;

--- a/Browser_IDE/handleUserInput.js
+++ b/Browser_IDE/handleUserInput.js
@@ -1,0 +1,16 @@
+function handleUserInput(event) {
+    if (event.key === "Enter") {
+        console.log("Event triggered:", event);
+        event.preventDefault();
+        const input = document.getElementById('user-input');
+        const output = document.getElementById('output');
+        const command = input.value;
+        input.value = ''; // Clear the input field
+
+        if (window.userInputResolve) {
+            output.value += "> " + command + "\n"; // Display the command in the output area
+            window.userInputResolve(command); // Resolve the Promise with the command
+            window.userInputResolve = null; // Reset the resolve function
+        }
+    }
+}

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -473,3 +473,31 @@ li.CodeMirror-hint-active {
   flex: 1 1 auto;
   padding: var(--bs-modal-padding);
 }
+
+#output {
+  background-color: #2e2e2e;
+  color: #dcdcdc; 
+  border: none;
+  padding: 15px; 
+  border-radius: 8px; 
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1); 
+  font-size: 16px; 
+  overflow-y: auto; 
+  max-height: 300px; 
+}
+
+#output::-webkit-scrollbar {
+  width: 5px;
+}
+
+#output::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+#output::-webkit-scrollbar-thumb {
+  background: #888;
+}
+
+#output::-webkit-scrollbar-thumb:hover {
+  background: #555;
+}


### PR DESCRIPTION
# Description

This pull request is to accomplish this trello task [Make `read_line()` work better ](https://trello.com/c/soKJafGa)

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Changed Files 
- Replace the third party `read_line()` method with the new JavaScript `read_line()` method.
- Add `read_line()` to `findGlobalDeclarationsTransform__awaitables` in `executionEnvironment_CodeProcessor.js` file.
- Create input display and `onkeydown="handleUserInput(event)"` in `executionEnvironment.html file`.
- Add `handleUserInput().js` file to process the message in input box.
- Add output message style in `css` file.

## Tested Screenshot
![image](https://github.com/thoth-tech/SplashkitOnline/assets/58095921/4eb4f115-d2ba-430f-a256-a4059e9fa2b1)