### PR TITLE
New folder button in tree view

### DIFF
--- a/Browser_IDE/fileview.js
+++ b/Browser_IDE/fileview.js
@@ -42,6 +42,20 @@ myTreeView.addEventListener("fileDeleteRequest", async function(e){
     }
 });
 
+myTreeView.addEventListener("folderCreateRequest", async (e) => {
+    try {
+        await unifiedFS.mkdir(
+            e.path,
+            e.FS.includes("transient"),
+            e.FS.includes("persistent")
+        );
+
+        if('onsuccess' in e) e.onsuccess();
+    } catch(err){
+        if('onerror' in e) e.onerror(err);
+    }
+});
+
 myTreeView.addEventListener("folderDeleteRequest", async function(e){
     try {
         await unifiedFS.rmdir(

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -220,7 +220,7 @@ textarea {
     flex-direction: row !important;
 	padding: 0px 20px 0px 0px;
 	margin-left: 6px;
-	color: red;
+	color: lightcoral;
 }
 .node-conflict-text{
 	flex: 1;

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -220,10 +220,12 @@ textarea {
     flex-direction: row !important;
 	padding: 0px 20px 0px 0px;
 	margin-left: 6px;
+	color: red;
 }
 .node-conflict-text{
 	flex: 1;
 	padding: 0px 0px 0px 3px;
+	text-wrap: nowrap;
 }
 
 .directory-contents{

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -211,7 +211,20 @@ textarea {
     color: #9fff69;
     opacity: 1.0;
 }
-
+.node-tentative-label{
+	margin: 0px 6px 0px 6px;
+}
+.node-conflict{
+	width:100%;
+	display:flex;
+    flex-direction: row !important;
+	padding: 0px 20px 0px 0px;
+	margin-left: 6px;
+}
+.node-conflict-text{
+	flex: 1;
+	padding: 0px 0px 0px 3px;
+}
 
 .directory-contents{
     padding:00px 0px 0px 30px;

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -354,7 +354,13 @@ class TreeView extends EventTarget{
         tentative_dir_node_text_area.classList.add("sk-input");
         tentative_dir_node_text_area.placeholder = "Folder name...";
 
+        let tentative_dir_node_conflict = document.createElement("div");
+        tentative_dir_node_conflict.classList.add("node-conflict", "bi-exclamation-octagon");
+        tentative_dir_node_conflict.style.display = "none";
+        tentative_dir_node_conflict.innerHTML = "Name conflict";
+
         tentative_dir_node_label.appendChild(tentative_dir_node_text_area);
+        tentative_dir_node_label.appendChild(tentative_dir_node_conflict);
         tentative_dir_node.appendChild(tentative_dir_node_label);
 
         tentative_dir_node_text_area.addEventListener("focusout", async (e) => {
@@ -362,6 +368,18 @@ class TreeView extends EventTarget{
         });
 
         let boundTree = this;
+
+        tentative_dir_node_text_area.addEventListener("keyup", async (e) => {
+            let newDirPath = boundTree.getFullPath(tentative_dir_node.parentElement.parentElement) + "/" + tentative_dir_node_text_area.value;
+            let existingNode = boundTree.getNodeFromPath(newDirPath);
+
+            if(existingNode != null){
+                tentative_dir_node_conflict.style.display = "initial";
+            } else {
+                tentative_dir_node_conflict.style.display = "none";
+            }
+        });
+
         tentative_dir_node_text_area.addEventListener("keydown", async (e) => {
             if(e.key == "Enter"){
                 e.preventDefault();
@@ -369,11 +387,6 @@ class TreeView extends EventTarget{
                 let newDirPath = boundTree.getFullPath(tentative_dir_node.parentElement.parentElement) + "/" + tentative_dir_node_text_area.value;
                 let existingNode = boundTree.getNodeFromPath(newDirPath);
                 if(existingNode != null) return;
-                // TODO: Provide better feedback to the user.
-                // We can't simply show a modal, 
-                // as then the input element would lose focus.
-                // Perhaps we could mirror VS Code's UX here,
-                // where the conflict is shown even before enter is pressed.
 
                 let ev = new Event("folderCreateRequest");
                 ev.treeView = boundTree;

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -362,6 +362,9 @@ class TreeView extends EventTarget{
             dir_node_delete_button.classList.add("bi-trash", "node-button");
         }
 
+        let dir_node_add_folder_button = document.createElement("button");
+        dir_node_add_folder_button.classList.add("bi-folder-plus", "node-button");
+
         let dir_node_label_text = document.createTextNode(label==""?"/":label);
 
         let dir_node_contents = document.createElement("div");
@@ -371,6 +374,7 @@ class TreeView extends EventTarget{
         dir_node_label_text_div.appendChild(dir_node_label_text);
         dir_node_label.appendChild(dir_node_label_text_div);
         dir_node_label.appendChild(dir_node_upload_file_button);
+        dir_node_label.appendChild(dir_node_add_folder_button);
 
         if(label != ""){
             dir_node_label.appendChild(dir_node_delete_button);
@@ -416,6 +420,11 @@ class TreeView extends EventTarget{
             ev.path = boundTree.getFullPath(dir_node);
             ev.FS = boundTree.nodeGetFS(dir_node);
             boundTree.dispatchEvent(ev);
+            e.stopPropagation();
+        });
+
+        dir_node_add_folder_button.addEventListener("click", async (e) => {
+            // TODO
             e.stopPropagation();
         });
 

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -338,6 +338,10 @@ class TreeView extends EventTarget{
         });
     }
 
+    /** 
+     * Represents a directory which is still yet to be named by the user and created.
+     * There should only exist one at a time.
+     * */
     makeTentativeDirectoryNode(){
         let tentative_dir_node = document.createElement("div");
         tentative_dir_node.classList.add("node", "directory");
@@ -362,6 +366,11 @@ class TreeView extends EventTarget{
                 let newDirPath = boundTree.getFullPath(tentative_dir_node.parentElement.parentElement) + "/" + tentative_dir_node_text_area.value;
                 let existingNode = boundTree.getNodeFromPath(newDirPath);
                 if(existingNode != null) return;
+                // TODO: Provide better feedback to the user.
+                // We can't simply show a modal, 
+                // as then the input element would lose focus.
+                // Perhaps we could mirror VS Code's UX here,
+                // where the conflict is shown even before enter is pressed.
 
                 let ev = new Event("folderCreateRequest");
                 ev.treeView = boundTree;

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -354,6 +354,9 @@ class TreeView extends EventTarget{
         tentative_dir_node_text_area.classList.add("sk-input");
         tentative_dir_node_text_area.placeholder = "Folder name...";
 
+        tentative_dir_node_label.appendChild(tentative_dir_node_text_area);
+        tentative_dir_node.appendChild(tentative_dir_node_label);
+
         tentative_dir_node_text_area.addEventListener("focusout", async (e) => {
             tentative_dir_node.remove();
         });
@@ -381,9 +384,6 @@ class TreeView extends EventTarget{
                 tentative_dir_node_text_area.blur(); // unfocus to remove
             }
         });
-
-        tentative_dir_node_label.appendChild(tentative_dir_node_text_area);
-        tentative_dir_node.appendChild(tentative_dir_node_label);
 
         tentative_dir_node.addEventListener("click", async (e) => {
             e.stopPropagation();

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -351,14 +351,18 @@ class TreeView extends EventTarget{
 
         let tentative_dir_node_text_area = document.createElement("input");
         tentative_dir_node_text_area.type = "text";
-        tentative_dir_node_text_area.classList.add("sk-input");
+        tentative_dir_node_text_area.classList.add("node-tentative-label", "sk-input");
         tentative_dir_node_text_area.placeholder = "Folder name...";
 
         let tentative_dir_node_conflict = document.createElement("div");
         tentative_dir_node_conflict.classList.add("node-conflict", "bi-exclamation-octagon");
         tentative_dir_node_conflict.style.display = "none";
-        tentative_dir_node_conflict.innerHTML = "Name conflict";
 
+        let tentative_dir_node_conflict_text = document.createElement("div");
+        tentative_dir_node_conflict_text.classList.add("node-conflict-text");
+        tentative_dir_node_conflict_text.innerHTML = "Name conflict";
+
+        tentative_dir_node_conflict.appendChild(tentative_dir_node_conflict_text);
         tentative_dir_node_label.appendChild(tentative_dir_node_text_area);
         tentative_dir_node_label.appendChild(tentative_dir_node_conflict);
         tentative_dir_node.appendChild(tentative_dir_node_label);
@@ -374,7 +378,7 @@ class TreeView extends EventTarget{
             let existingNode = boundTree.getNodeFromPath(newDirPath);
 
             if(existingNode != null){
-                tentative_dir_node_conflict.style.display = "initial";
+                tentative_dir_node_conflict.style.display = "inherit";
             } else {
                 tentative_dir_node_conflict.style.display = "none";
             }

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -338,6 +338,48 @@ class TreeView extends EventTarget{
         });
     }
 
+    makeTentativeDirectoryNode(){
+        let tentative_dir_node = document.createElement("div");
+        tentative_dir_node.classList.add("node", "directory");
+
+        let tentative_dir_node_label = document.createElement("div");
+        tentative_dir_node_label.classList.add("node-label", "bi-folder2-open");
+
+        let tentative_dir_node_text_area = document.createElement("input");
+        tentative_dir_node_text_area.type = "text";
+        tentative_dir_node_text_area.classList.add("sk-input");
+        tentative_dir_node_text_area.placeholder = "Folder name...";
+
+        tentative_dir_node_text_area.addEventListener("focusout", async (e) => {
+            tentative_dir_node.remove();
+        });
+
+        let boundTree = this;
+        tentative_dir_node_text_area.addEventListener("keydown", async (e) => {
+            if(e.key == "Enter"){
+                e.preventDefault();
+
+                let newDirPath = boundTree.getFullPath(tentative_dir_node.parentElement.parentElement) + "/" + tentative_dir_node_text_area.value;
+                let existingNode = boundTree.getNodeFromPath(newDirPath);
+                if(existingNode != null) return;
+
+                // TODO: Create folder in FS
+
+                tentative_dir_node_text_area.blur(); // unfocus to remove
+            }
+        });
+
+        tentative_dir_node_label.appendChild(tentative_dir_node_text_area);
+        tentative_dir_node.appendChild(tentative_dir_node_label);
+
+        tentative_dir_node.addEventListener("click", async (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+        });
+
+        return tentative_dir_node;
+    }
+
     makeDirectoryNode(label){
         let dir_node = document.createElement("div");
         dir_node.classList.add("node");
@@ -424,7 +466,9 @@ class TreeView extends EventTarget{
         });
 
         dir_node_add_folder_button.addEventListener("click", async (e) => {
-            // TODO
+            let tentativeNode = this.makeTentativeDirectoryNode();
+            this.getDirectoryContents(dir_node).appendChild(tentativeNode);
+            tentativeNode.querySelector("input").focus();
             e.stopPropagation();
         });
 

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -352,7 +352,8 @@ class TreeView extends EventTarget{
         let tentative_dir_node_text_area = document.createElement("input");
         tentative_dir_node_text_area.type = "text";
         tentative_dir_node_text_area.classList.add("node-tentative-label", "sk-input");
-        tentative_dir_node_text_area.placeholder = "Folder name...";
+        tentative_dir_node_text_area.placeholder = "";
+        tentative_dir_node_text_area.size = 5;
 
         let tentative_dir_node_conflict = document.createElement("div");
         tentative_dir_node_conflict.classList.add("node-conflict", "bi-exclamation-octagon");
@@ -372,6 +373,10 @@ class TreeView extends EventTarget{
         });
 
         let boundTree = this;
+
+        tentative_dir_node_text_area.addEventListener("input", async (e) => {
+            tentative_dir_node_text_area.size = Math.max(5, tentative_dir_node_text_area.value.length);
+        });
 
         tentative_dir_node_text_area.addEventListener("keyup", async (e) => {
             let newDirPath = boundTree.getFullPath(tentative_dir_node.parentElement.parentElement) + "/" + tentative_dir_node_text_area.value;

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -363,7 +363,11 @@ class TreeView extends EventTarget{
                 let existingNode = boundTree.getNodeFromPath(newDirPath);
                 if(existingNode != null) return;
 
-                // TODO: Create folder in FS
+                let ev = new Event("folderCreateRequest");
+                ev.treeView = boundTree;
+                ev.path = newDirPath;
+                ev.FS = boundTree.nodeGetFS(tentative_dir_node.parentElement.parentElement);
+                boundTree.dispatchEvent(ev);
 
                 tentative_dir_node_text_area.blur(); // unfocus to remove
             }

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -406,6 +406,12 @@ class TreeView extends EventTarget{
                 ev.treeView = boundTree;
                 ev.path = newDirPath;
                 ev.FS = boundTree.nodeGetFS(tentative_dir_node.parentElement.parentElement);
+                ev.onerror = (err) => {
+                    let errEv = new Event("filesystemError");
+                    errEv.shortMessage = "Folder creation failed";
+                    errEv.longMessage = "An error occured and the folder could not be created.\n\nReason:\n" + err;
+                    window.dispatchEvent(errEv);
+                };
                 boundTree.dispatchEvent(ev);
 
                 tentative_dir_node_text_area.blur(); // unfocus to remove

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -385,6 +385,11 @@ class TreeView extends EventTarget{
         });
 
         tentative_dir_node_text_area.addEventListener("keydown", async (e) => {
+            if(e.key == "Escape"){
+                tentative_dir_node_text_area.blur();
+                return;
+            }
+
             if(e.key == "Enter"){
                 e.preventDefault();
 


### PR DESCRIPTION
# Description

Adds a button to directory nodes in the file tree view that allows the user to create a new folder with a given name.

![new-folder-button](https://github.com/thoth-tech/SplashkitOnline/assets/129343526/326e827b-9ad4-4eb4-bdae-0ea6bd3907a2)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I have tested this UI interaction by:
- creating new folders in the root directory and in subdirectories,
- beginning to create a folder, then cancelling by interacting with something else in the UI,
- creating a folder with the same name as a folder in the directory,
- creating a folder with the same name as a folder in another directory.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
