### PR TITLE
Setup a splitter between canvas and terminal

### DIFF
--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -9,14 +9,15 @@
 
     <link rel="stylesheet" href="stylesheet.css">
     <script src="babel/babel.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/split.js@1.6.2"></script>
 </head>
 
 <body class="sk-body">
 	<div class="sk-column" style="max-height: 100%;">
-		<div class="sk-contents" style="flex-direction: row; max-height: 85%;">
+		<div id="canvasContainer" class="sk-contents" style="flex-direction: row; max-height: 85%;">
 			<canvas id="canvas" style="margin:auto; vertical-align:center; max-height: 100%; left:0px; right:0px; width:inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
 		</div>
-		<div class="sk-header sk-header-indent">
+		<div id="terminalOutputContainer" class="sk-header sk-header-indent">
 			TERMINAL OUTPUT
 		</div>
 		<div class="sk-contents">

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -496,3 +496,14 @@ moduleEvents.addEventListener("onRuntimeInitialized", function() {
 
     parent.postMessage({type:"initialized"},"*");
 });
+
+document.addEventListener('DOMContentLoaded', function() {
+    Split(['#canvasContainer', '#terminalOutputContainer'], {
+        direction: 'vertical',  
+        sizes: [75, 25],        
+        minSize: [100, 100],   
+        gutterSize: 5,          
+        gutterAlign: 'center',  
+        cursor: 'row-resize'    
+    });
+});


### PR DESCRIPTION
# Description

Made a splitter between canvas and Terminal Output, so that the height of the terminal can be resized by dragging. 

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?
Tested in Microsoft Edge and Google

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
