### PR TITLE
Made Terminal Output height to be increased

### DIFF
--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -14,16 +14,16 @@
 </head>
 
 <body class="sk-body">
-	<div class="sk-column" style="height: 100%; display: flex; flex-direction: column;">
-		<div id="canvasContainer" style="flex-grow: 1; display: flex;">
-			<canvas id="canvas" style="margin:auto; vertical-align: center; height: 100%; left:0px; right:0px; width: inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
+	<div class="sk-column" style = "height: 100%; display: flex; flex-direction: column;">
+		<div id="canvasContainer" style = "flex-grow: 1; display: flex;">
+			<canvas id="canvas" style = "margin:auto; vertical-align: center; height: 100%; left:0px; right:0px; width: inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
 		</div>
 		<div id="terminalOutputContainer" style="flex-grow: 0; display: flex; flex-direction: column;">
 			<div class="sk-header sk-header-indent">
 				TERMINAL OUTPUT
 			</div>
 			<div class="sk-contents">
-				<textarea id="output" class="sk-contents sk-contents-darker" readonly="" style="border:0; padding-left:1em; resize: none; width: 100%; height: 100%;"></textarea>
+				<textarea id="output" class="sk-contents sk-contents-darker" readonly="" style = "border:0; padding-left:1em; resize: none; width: 100%; height: 100%;"></textarea>
 			</div>
 		</div>
 	</div>

--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -9,21 +9,26 @@
 
     <link rel="stylesheet" href="stylesheet.css">
     <script src="babel/babel.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/split.js@1.6.2"></script>
+
 </head>
 
 <body class="sk-body">
-	<div class="sk-column" style="max-height: 100%;">
-		<div class="sk-contents" style="flex-direction: row; max-height: 85%;">
-			<canvas id="canvas" style="margin:auto; vertical-align:center; max-height: 100%; left:0px; right:0px; width:inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+	<div class="sk-column" style="height: 100%; display: flex; flex-direction: column;">
+		<div id="canvasContainer" style="flex-grow: 1; display: flex;">
+			<canvas id="canvas" style="margin:auto; vertical-align: center; height: 100%; left:0px; right:0px; width: inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
 		</div>
-		<div class="sk-header sk-header-indent">
-			TERMINAL OUTPUT
-		</div>
-		<div class="sk-contents">
-			<textarea id="output" class="sk-contents sk-contents-darker" readonly style="border:0; padding-left:1em; resize: none;"></textarea>
+		<div id="terminalOutputContainer" style="flex-grow: 0; display: flex; flex-direction: column;">
+			<div class="sk-header sk-header-indent">
+				TERMINAL OUTPUT
+			</div>
+			<div class="sk-contents">
+				<textarea id="output" class="sk-contents sk-contents-darker" readonly="" style="border:0; padding-left:1em; resize: none; width: 100%; height: 100%;"></textarea>
+			</div>
 		</div>
 	</div>
 </body>
+
 
 <script src="moduleEventTarget.js"></script>
 <script src="loadsplashkit.js"></script>

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -496,3 +496,15 @@ moduleEvents.addEventListener("onRuntimeInitialized", function() {
 
     parent.postMessage({type:"initialized"},"*");
 });
+
+
+document.addEventListener('DOMContentLoaded', function() {
+    Split(['#canvasContainer', '#terminalOutputContainer'], {
+        direction: 'vertical',  
+        sizes: [75, 25],        
+        minSize: [100, 100],   
+        gutterSize: 5,          
+        gutterAlign: 'center',  
+        cursor: 'row-resize'    
+    });
+});

--- a/Browser_IDE/executionEnvironment_Internal.js
+++ b/Browser_IDE/executionEnvironment_Internal.js
@@ -497,14 +497,36 @@ moduleEvents.addEventListener("onRuntimeInitialized", function() {
     parent.postMessage({type:"initialized"},"*");
 });
 
+window.addEventListener('load', function() {
+    resizeCanvas(); 
+});
 
-document.addEventListener('DOMContentLoaded', function() {
-    Split(['#canvasContainer', '#terminalOutputContainer'], {
-        direction: 'vertical',  
-        sizes: [75, 25],        
-        minSize: [100, 100],   
-        gutterSize: 5,          
-        gutterAlign: 'center',  
-        cursor: 'row-resize'    
-    });
+function resizeCanvas() {
+    const container = document.getElementById('canvasContainer');
+    const maxWidth = container.clientWidth;
+    const maxHeight = container.clientHeight;
+    const aspectRatio = 4 / 3;
+    let newWidth = maxHeight * aspectRatio;
+    let newHeight = maxHeight;
+
+    
+    if (newWidth > maxWidth) {
+        newWidth = maxWidth;
+        newHeight = maxWidth / aspectRatio;
+    }
+    
+    const canvas = document.getElementById('canvas');
+    canvas.style.width = `${newWidth}px`;
+    canvas.style.height = `${newHeight}px`;
+    
+    canvas.style.left = `${(maxWidth - newWidth) / 2}px`;
+}
+
+Split(['#canvasContainer', '#terminalOutputContainer'], {
+    direction: 'vertical',
+    sizes: [75, 25],
+    minSize: [100, 100],
+    gutterSize: 5,
+    gutterAlign: 'center',
+    onDrag: resizeCanvas 
 });

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -170,7 +170,13 @@ textarea {
     z-index:100;
 }
 
+.gutter-vertical {
+  cursor: ns-resize;
+}
 
+.gutter-horizontal {
+  cursor: e-resize;
+}
 
 .node{
     color:#f8f8f2;
@@ -472,4 +478,9 @@ li.CodeMirror-hint-active {
   position: relative;
   flex: 1 1 auto;
   padding: var(--bs-modal-padding);
+}
+
+#canvas {  
+  max-width: 100%;
+  max-height: 100%;
 }


### PR DESCRIPTION
# Description

Setup a splitter between canvas and terminal, which made the 'Terminal Output' container' height able to be increased upon dragging. 

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration_

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
