### PR TITLE
Error propagation from IDB FS transactions

### DIFF
--- a/Browser_IDE/IDBStoredProject.js
+++ b/Browser_IDE/IDBStoredProject.js
@@ -316,9 +316,9 @@ class __IDBStoredProjectRW{
     // "Private" Methods
 
     // Transactions Wrappers - to make them promises
-    async doTransaction(store, state, func)
+    doTransaction(store, state, func)
     {
-        return await (new Promise(async (resolve, reject) => {
+        return new Promise(async (resolve, reject) => {
             let transaction = this.db.transaction(store, state);
             let files = transaction.objectStore(store);
             let result = undefined;
@@ -332,11 +332,11 @@ class __IDBStoredProjectRW{
 
             transaction.onerror = function(){console.log("error");transaction.abort(); reject(transaction.error);};
             transaction.oncomplete = function(){resolve(result);};
-        }));
+        });
     }
-    async request(transaction, func)
+    request(transaction, func)
     {
-        return await (new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             let result = undefined;
             
             try {
@@ -348,7 +348,7 @@ class __IDBStoredProjectRW{
 
             result.onerror = function(){console.log("error");transaction.abort(); reject(transaction.error);};
             result.onsuccess = function(){resolve(result.result);};
-        }));
+        });
     }
 
     // Basic Node Handling

--- a/Browser_IDE/IDBStoredProject.js
+++ b/Browser_IDE/IDBStoredProject.js
@@ -346,7 +346,7 @@ class __IDBStoredProjectRW{
                 return;
             }
 
-            result.onerror = function(){console.log("error");transaction.abort(); reject(transaction.error);};
+            result.onerror = function(){console.log("error");transaction.abort(); reject(result.error);};
             result.onsuccess = function(){resolve(result.result);};
         });
     }

--- a/Browser_IDE/IDBStoredProject.js
+++ b/Browser_IDE/IDBStoredProject.js
@@ -367,7 +367,6 @@ class __IDBStoredProjectRW{
     async deleteNode(transaction, files, nodeId){
         this.performedWrite = true;
         return await this.request(transaction, function(){
-            throw new Error("test deleteNode fail");
             return files.delete(nodeId);
         });
     }

--- a/Browser_IDE/IDBStoredProject.js
+++ b/Browser_IDE/IDBStoredProject.js
@@ -346,7 +346,7 @@ class __IDBStoredProjectRW{
                 return;
             }
 
-            transaction.onerror = function(){console.log("error");transaction.abort(); reject(transaction.error);};
+            result.onerror = function(){console.log("error");transaction.abort(); reject(transaction.error);};
             result.onsuccess = function(){resolve(result.result);};
         }));
     }

--- a/Browser_IDE/treeview.js
+++ b/Browser_IDE/treeview.js
@@ -530,6 +530,12 @@ class TreeView extends EventTarget{
                     deleteEv.treeView = boundTree;
                     deleteEv.path = boundTree.getFullPath(dir_node);
                     deleteEv.FS = boundTree.nodeGetFS(dir_node);
+                    deleteEv.onerror = (err)=>{
+                        let errEv = new Event("filesystemError");
+                        errEv.shortMessage = "Folder deletion failed";
+                        errEv.longMessage = "An error occured and the folder could not be deleted.\n\nReason:\n" + err;
+                        window.dispatchEvent(errEv);
+                    }
                     boundTree.dispatchEvent(deleteEv);
                 };
                 window.dispatchEvent(confirmEv);
@@ -591,6 +597,12 @@ class TreeView extends EventTarget{
                 deleteEv.treeView = boundTree;
                 deleteEv.path = boundTree.getFullPath(file_node_label);
                 deleteEv.FS = boundTree.nodeGetFS(file_node_label);
+                deleteEv.onerror = (err)=>{
+                    let errEv = new Event("filesystemError");
+                    errEv.shortMessage = "File deletion failed";
+                    errEv.longMessage = "An error occured and the file could not be deleted.\n\nReason:\n" + err;
+                    window.dispatchEvent(errEv);
+                }
                 boundTree.dispatchEvent(deleteEv);
             };
             window.dispatchEvent(confirmEv);


### PR DESCRIPTION
# Description

I have rewritten `doTransaction` and `request` in the `IDBStoredProject` class so that they are able to propagate errors thrown by the callback that they are supplied with, as this seems not to have worked previously. This would have been part of [PR48](https://github.com/thoth-tech/SplashkitOnline/pull/48), had I noticed it earlier.

The PR also contains a minor fix which adds error handling to the deletion interaction, which a commit of mine in PR48 erroneously claimed to have implemented, when it was in fact only partly done.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have tested this by inserting test errors into the callbacks supplied to the relevant functions, verifying that the error propagates upwards to the interaction that initiated the filesystem operation, to be displayed to the user.

I have also tested normal interactions such as uploading files, creating folders, deleting FS nodes, running the program, etc. in order to ensure that nothing has ceased working.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request

## Specific feedback desired

- Does the synchronous calling of async. functions that were previously called asynchronously pose any problem to the site's execution? Could this impair performance or fluidity?
- Have I misunderstood the intended structure of the codebase?