### PR TITLE
Make Export Project download a zip

### DIFF
--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -138,7 +138,7 @@ async function newProject(){
     disableCodeExecution();
     storedProject.detachFromProject();
     canMirror = false;
-    await executionEnviroment.resetEnvironment();
+    executionEnviroment.resetEnvironment();
     await storedProject.deleteProject("Untitled");
     haveMirrored = false;
     await storedProject.attachToProject("Untitled");
@@ -488,26 +488,10 @@ async function FSdownloadFile(filename, mime) {
 }
 
 
-async function downloadProject(projectName){
+async function downloadProject(){
     let projectName = (await appStorage.access((s) => s.getProject(storedProject.projectID))).name;
     downloadFileGeneric(await projectToZip(), projectName + ".zip");
 }
-
-document.getElementById("DownloadProject").addEventListener("click", async function (e) {
-    downloadProject();
-    e.stopPropagation();
-});**
-document.getElementById("UploadProject").addEventListener("click", function (e) {
-    document.getElementById("projectuploader").click();
-    e.stopPropagation();
-});
-document.getElementById("NewProject").addEventListener("click", async function (e) {
-    newProject();
-    e.stopPropagation();
-});
-}
-
-
 
 
 // ------ Project Zipping/Unzipping Click Handling ------
@@ -519,7 +503,7 @@ async function uploadProjectFromInput(){
     projectFromZip(file);
 }
 document.getElementById("DownloadProject").addEventListener("click", async function (e) {
-    downloadProject('MyProject');
+    downloadProject();
     e.stopPropagation();
 });
 document.getElementById("UploadProject").addEventListener("click", function (e) {

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -138,7 +138,7 @@ async function newProject(){
     disableCodeExecution();
     storedProject.detachFromProject();
     canMirror = false;
-    executionEnviroment.resetEnvironment();
+    await executionEnviroment.resetEnvironment();
     await storedProject.deleteProject("Untitled");
     haveMirrored = false;
     await storedProject.attachToProject("Untitled");
@@ -488,9 +488,10 @@ async function FSdownloadFile(filename, mime) {
 }
 
 
-async function downloadProject(){
-    downloadFileGeneric(await projectToZip(), "project.zip");
+async function downloadProject(projectName){
+    downloadFileGeneric(await projectToZip(), projectName + ".zip");
 }
+
 
 
 
@@ -503,7 +504,7 @@ async function uploadProjectFromInput(){
     projectFromZip(file);
 }
 document.getElementById("DownloadProject").addEventListener("click", async function (e) {
-    downloadProject();
+    downloadProject('MyProject');
     e.stopPropagation();
 });
 document.getElementById("UploadProject").addEventListener("click", function (e) {

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -489,7 +489,22 @@ async function FSdownloadFile(filename, mime) {
 
 
 async function downloadProject(projectName){
+    let projectName = (await appStorage.access((s) => s.getProject(storedProject.projectID))).name;
     downloadFileGeneric(await projectToZip(), projectName + ".zip");
+}
+
+document.getElementById("DownloadProject").addEventListener("click", async function (e) {
+    downloadProject();
+    e.stopPropagation();
+});**
+document.getElementById("UploadProject").addEventListener("click", function (e) {
+    document.getElementById("projectuploader").click();
+    e.stopPropagation();
+});
+document.getElementById("NewProject").addEventListener("click", async function (e) {
+    newProject();
+    e.stopPropagation();
+});
 }
 
 


### PR DESCRIPTION
# Description
Adjusted the "Export Project" feature to download a zip file named after the project (rather than simply "project.zip").

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration_

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
