### PR TITLE
Add language selection element

### DIFF
--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -120,6 +120,29 @@ for (let i = 0; i < tabElems.length; i++) {
 
 SwitchToTabs(tabs[0].contents.id);
 
+// setup language selection box
+let languageSelectElem = document.getElementById("languageSelection");
+for (let i = 0; i < SplashKitOnlineLanguageDefinitions.length; i++) {
+    let language = SplashKitOnlineLanguageDefinitions[i];
+    languageSelectElem.append(elem("option", {value: language.name}, [language.userVisibleName]));
+}
+
+// switch active language
+// currently just reloads the page with the 'language' parameter set
+// in the future, ideally this will work _without_ reloading the page,
+// by unloading the existing language scripts then loading the new ones
+function switchActiveLanguage(language){
+     let page_url = new URL(window.location.href);
+     page_url.searchParams.set('language', language.replaceAll("+"," ") /* spaces become + in url */);
+     window.location = page_url;
+}
+
+languageSelectElem.addEventListener('change', function(event) {
+    // just switch active language
+    // TODO: store chosen language inside project
+    switchActiveLanguage(event.target.value);
+})
+
 // ------ Setup Project and Execution Environment ------
 
 // decide which language to use
@@ -132,11 +155,13 @@ if (SKO.language in SplashKitOnlineLanguageAliasMap) {
 
     displayEditorNotification("Unable to switch to language "+SKO.language+", defaulting to JavaScript.", NotificationIcons.ERROR, -1);
     displayEditorNotification("Available languages are: <br/><ul>"+
-        SplashKitOnlineLanguageDefinitions.map(val => `<li>${val.name}</li>`).join("")+
+        SplashKitOnlineLanguageDefinitions.map(val => `<li>${val.userVisibleName}</li>`).join("")+
         "</ul>", NotificationIcons.ERROR, -1
     );
 }
 activeLanguageSetup = activeLanguage.setups[0];
+
+languageSelectElem.value = activeLanguage.name;
 
 // initialize language
 initializeLanguageCompilerFiles(activeLanguageSetup);

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -40,6 +40,13 @@
 			<li><button id="DownloadProject">Export Project</button></li>
 			<li><button id="UploadProject">Import Project</button></li>
 		</ul>
+        <ul class="sk-menu">
+            <li>
+                <div>Language:&nbsp;</div>
+                <select id="languageSelection">
+                </select>
+            </li>
+        </ul>
 	</div>
 	<div class="sk-main-columns">
 		<div class="sk-column" id="fileViewContainer">

--- a/Browser_IDE/languageDefinitions.js
+++ b/Browser_IDE/languageDefinitions.js
@@ -13,6 +13,7 @@
 let SplashKitOnlineLanguageDefinitions = [
     {
         name: "JavaScript",
+        userVisibleName: "JavaScript",
         aliases: ['JS'],
         setups: [{
             name: "JavaScript Native",
@@ -42,6 +43,7 @@ let SplashKitOnlineLanguageDefinitions = [
     },
     {
         name: "C++",
+        userVisibleName: "C++ (Experimental)",
         aliases: ['CXX','C'],
         setups: [{
             name: "C++ (Clang)",
@@ -75,6 +77,7 @@ function makeAliasMap(languages){
         let language = languages[i];
 
         aliasMap[language.name] = language;
+        aliasMap[language.userVisibleName] = language;
 
         for (let i = 0; i < language.aliases.length; i ++) {
             aliasMap[language.aliases[i]] = language;

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -53,6 +53,29 @@ button:hover {
     background-color: #404040;
 }
 
+select {
+    -webkit-appearance: button;
+    -moz-appearance: button;
+
+    margin: 0px 3px;
+    border-radius: 3px;
+    border: 0px black solid;
+    background-color: transparent;
+    color: inherit;
+    cursor: pointer;
+    outline:none;
+    line-height: 1em;
+}
+
+select:disabled {
+    color: #AAA;
+}
+
+select:hover {
+    background-color: #303030;
+}
+
+
 a:visited {
     color: #0A0;
 }


### PR DESCRIPTION
# Description

Adds a drop down menu for selecting the current language. Currently this works by just reloading the page with the 'language' parameter set.
![language_select](https://github.com/thoth-tech/SplashkitOnline/assets/42032199/2d22faf7-a7d1-4fe9-9844-e1f61b42a35b)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Different language options have been selected and the url has been checked to make sure it changed correctly.
- Also tested adding extra parameters to the url and ensuring they remain as-is

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
