### PR TITLE
Terminal height made resizable and canvas scalling fixed

### DIFF
--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -6,24 +6,27 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SplashKit Runtime</title>
-
     <link rel="stylesheet" href="stylesheet.css">
+    <script src="split.js/split.min.js"></script>
 </head>
 
 <body class="sk-body">
-	<div class="sk-column" style="max-height: 100%;">
-		<div class="sk-contents" style="flex-direction: row; max-height: 85%;">
-			<canvas id="canvas" style="margin:auto; vertical-align:center; max-height: 100%; left:0px; right:0px; width:inherit; outline: none;" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
-		</div>
-		<div class="sk-header sk-header-indent">
-			TERMINAL OUTPUT
-			<button id="clearButton" class="btn btn-outline-secondary btn-sm ms-2" onclick="clearTerminal()">Clear</button>
-		</div>
-		<div class="sk-contents">
-			<div id="output" class="sk-contents sk-contents-darker sk-terminal"></div>
-		</div>
-	</div>
+    <div class="sk-column" style="height: 100%; display: flex; flex-direction: column;">
+        <div id="canvasContainer" style="flex-grow: 1; display: flex; position: relative;">
+            <canvas id="canvas" style="margin: auto; outline: none;" oncontextmenu="event.preventDefault()" tabindex="-1"></canvas>
+        </div>
+        <div id="terminalOutputContainer" style="flex-grow: 0; display: flex; flex-direction: column;">
+            <div class="sk-header sk-header-indent">
+                TERMINAL OUTPUT
+                <button id="clearButton" class="btn btn-outline-secondary btn-sm ms-2" onclick="clearTerminal()">Clear</button>
+            </div>
+            <div class="sk-contents">
+                <div id="output" class="sk-contents sk-contents-darker sk-terminal"></div>
+            </div>
+        </div>
+    </div>
 </body>
 
 <script src="runtimes/ExecutionEnvironmentInternalLoader.js"></script>
+
 </html>

--- a/Browser_IDE/executionEnvironment_Page.js
+++ b/Browser_IDE/executionEnvironment_Page.js
@@ -111,3 +111,11 @@ function ReportError(block, message, line, formatted=false){
         line: line
     },"*");
 }
+
+Split(['#canvasContainer', '#terminalOutputContainer'], {
+    direction: 'vertical',
+    sizes: [75, 25],
+    minSize: [100, 100],
+    gutterSize: 5,
+    gutterAlign: 'center',     
+});

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -197,6 +197,13 @@ textarea {
     z-index:100;
 }
 
+.gutter-vertical {
+  cursor: ns-resize;
+}
+
+.gutter-horizontal {
+  cursor: e-resize;
+}
 
 .sk-notification-area {
     position: absolute;
@@ -228,7 +235,7 @@ textarea {
 
 .sk-terminal {
     overflow-y: scroll;
-    height:200px;
+    flex-basis: 0;
     border:0;
     padding-left:1em;
     resize: none;
@@ -575,3 +582,8 @@ li.CodeMirror-hint-active {
 .sk-term-fmt-code35, .sk-term-fmt-code95 {color: magenta;}
 .sk-term-fmt-code36, .sk-term-fmt-code96 {color: cyan;}
 .sk-term-fmt-code37, .sk-term-fmt-code97 {color: white;}
+
+#canvas {  
+  max-width: 100%;
+  max-height: 100%;
+}


### PR DESCRIPTION
# Description

Made the Terminal Output resizable vertically along with fixing of canvas scaling.

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration_

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
