### PR TITLE
Compress C++ binaries for faster loading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = SplashKitWasm/external/splashkit-core
 	url = https://github.com/thoth-tech/splashkit-core.git
 	ignore = dirty
+[submodule "Browser_IDE/external/js-lzma"]
+	path = Browser_IDE/external/js-lzma
+	url = https://github.com/jcmellado/js-lzma

--- a/Browser_IDE/compilers/cxx/cxxCompilerClangBackend.js
+++ b/Browser_IDE/compilers/cxx/cxxCompilerClangBackend.js
@@ -1,21 +1,11 @@
 // function to load the system libraries zip file
 async function loadSystemRootFiles(){
-    return new Promise((resolve, reject) => {
-        var xhr = new XMLHttpRequest();
-        xhr.responseType = 'arraybuffer';
-        xhr.onreadystatechange = function(){
-            if (xhr.readyState === 4) {
-                if (xhr.status === 0 || xhr.status === 200) {
-                    resolve(xhr.response);
-                }
-                else{
-                    reject(new Error("Couldn't load the compiler system root files!"));
-                }
-            }
-        };
-        xhr.open("GET", "compilers/cxx/bin/wasi-sysroot.zip", true);
-        xhr.send(null);
-    });
+    try {
+        return await downloadFile("compilers/cxx/bin/wasi-sysroot.zip", null, true);
+    }
+    catch(err) {
+        throw new Error("Couldn't load the compiler system root files!<br/>"+err.toString());
+    }
 }
 
 // utility functions for reporting errors from Clang
@@ -85,7 +75,8 @@ w.onmessage = function(event){
 // initialize the compilers
 await postMessageFallible(w, {
     type: "initialize",
-    sysroot: await loadSystemRootFiles()
+    sysroot: await loadSystemRootFiles(),
+    SKO: SKO,
 });
 
 // export functions to compile and link objects - this is used in the main cxxCompiler.js

--- a/Browser_IDE/compilers/cxx/cxxCompilerClangBackend.js
+++ b/Browser_IDE/compilers/cxx/cxxCompilerClangBackend.js
@@ -1,13 +1,3 @@
-// function to load the system libraries zip file
-async function loadSystemRootFiles(){
-    try {
-        return await downloadFile("compilers/cxx/bin/wasi-sysroot.zip", null, true);
-    }
-    catch(err) {
-        throw new Error("Couldn't load the compiler system root files!<br/>"+err.toString());
-    }
-}
-
 // utility functions for reporting errors from Clang
 function removeAnsiFromString(text){
     return text.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
@@ -75,7 +65,6 @@ w.onmessage = function(event){
 // initialize the compilers
 await postMessageFallible(w, {
     type: "initialize",
-    sysroot: await loadSystemRootFiles(),
     SKO: SKO,
 });
 

--- a/Browser_IDE/compilers/cxx/cxxCompilerClangWebWorker.js
+++ b/Browser_IDE/compilers/cxx/cxxCompilerClangWebWorker.js
@@ -8,6 +8,16 @@ importScripts('./../../external/js-lzma/src/lzma.shim.js');
 self.wlzmaCustomPath = "./../../external/js-lzma/src/wlzma.wrk.js";
 importScripts('./../../downloadHandler.js');
 
+// function to load the system libraries zip file
+async function loadSystemRootFiles(){
+    try {
+        return await downloadFile("bin/wasi-sysroot.zip", null, true);
+    }
+    catch(err) {
+        throw new Error("Failed to load compiler system root files: \""+err.toString()+"\"</br> Please check that the files are installed correctly.");
+    }
+}
+
 // function to load in the system root files from a zip file
 async function preloadSysroot(FS, sysroot){
     let contents = [];
@@ -97,8 +107,9 @@ onmessage = async function(event){
                     throw new Error("Failed to load Wasm-ld: \""+err.toString()+"\"</br> Please check that the files are installed correctly.");
                 }
 
-                await initializeCompiler();
-                await initializeSystemRoot(event.data.sysroot);
+                let [ , rootFiles] = await Promise.all([initializeCompiler(), loadSystemRootFiles()]);
+                await initializeSystemRoot(rootFiles);
+
                 resolveMessageFallible(event);
                 break;
             case "setupUserCode":

--- a/Browser_IDE/compilers/cxx/cxxCompilerClangWebWorker.js
+++ b/Browser_IDE/compilers/cxx/cxxCompilerClangWebWorker.js
@@ -1,5 +1,12 @@
+let SKO = null;
+
 importScripts('./../../jszip/jszip.min.js');
 importScripts('./../../fallibleMessage.js');
+importScripts('./../../external/js-lzma/src/wlzma.js');
+importScripts('./../../external/js-lzma/src/lzma.shim.js');
+
+self.wlzmaCustomPath = "./../../external/js-lzma/src/wlzma.wrk.js";
+importScripts('./../../downloadHandler.js');
 
 // function to load in the system root files from a zip file
 async function preloadSysroot(FS, sysroot){
@@ -57,7 +64,7 @@ function print(message){
 }
 
 // initial settings for the modules
-function initSettings() {
+function initSettings(binary) {
     return {
         noExitRuntime: true,
         printErr: print,
@@ -65,6 +72,7 @@ function initSettings() {
         locateFile: function(file){
             return "bin/"+file;
         },
+        wasmBinary: binary,
     }
 }
 
@@ -77,6 +85,8 @@ onmessage = async function(event){
     try {
         switch (event.data.type) {
             case "initialize":
+                SKO = event.data.SKO;
+
                 try { importScripts('./bin/clang++.js'); }
                 catch(err) {
                     throw new Error("Failed to load Clang++: \""+err.toString()+"\"</br> Please check that the files are installed correctly.");
@@ -121,9 +131,15 @@ onmessage = async function(event){
 
 // initialize the compilers, and tidy their output
 async function initializeCompiler(){
-    clang = await Clang(initSettings());
-    lld = await Lld(initSettings());
+    await Promise.all([
+        downloadFile("bin/clang.wasm", null, true)
+            .then((binary) => Clang(initSettings(binary)))
+            .then((result) => {clang = result;}),
 
+        downloadFile("bin/lld.wasm", null, true)
+            .then((binary) => Lld(initSettings(binary)))
+            .then((result) => {lld = result;})
+    ]);
     // Lld and Clang doesn't really like us re-running their mains over and over,
     // and ask us to submit a bug report - let's let them get it out of their system once here
     // so the user doesn't need to see it...this feels wrong (´；ω；`)ｳｩｩ

--- a/Browser_IDE/downloadHandler.js
+++ b/Browser_IDE/downloadHandler.js
@@ -1,0 +1,55 @@
+"use strict";
+
+let wlzmaPath = self['wlzmaCustomPath'] || "./external/js-lzma/src/wlzma.wrk.js";
+
+function XMLHttpRequestPromise(url, progressCallback, type="GET") {
+    return new Promise(function (resolve, reject) {
+        let req = new XMLHttpRequest();
+        req.responseType = 'arraybuffer';
+
+        if (progressCallback != null)
+            req.addEventListener("progress", function(event) {
+                if (event.lengthComputable)
+                    progressCallback(event.loaded / event.total);
+            }, false);
+
+        req.addEventListener("loadend", function(event) {
+            if (event.target.status != 200){
+                reject(event.target);
+            }
+
+            resolve(event.target);
+        }, false);
+
+        req.open(type, url);
+        req.send();
+    });
+}
+
+let wlzma = new WLZMA.Manager(0, wlzmaPath);
+
+async function downloadFile(url, progressCallback = null, maybeLZMACompressed = false){
+    // First try downloading the LZMA version
+    if (maybeLZMACompressed && SKO.useCompressedBinaries) {
+        let exists = false;
+        try {
+            await XMLHttpRequestPromise(url+".lzma", progressCallback, "HEAD");
+            exists = true;
+        }
+        catch (err) {}
+
+        // seems alright, let's try downloading it properly!
+        if (exists) {
+            let decompressionPercentage = 0.2;
+            let downloadPercentage = 1.0 - decompressionPercentage;
+            let downloadProgressCallback = (progressCallback==null) ? null : function(percentage) { progressCallback(percentage * downloadPercentage); };
+            let compressed = await XMLHttpRequestPromise(url+".lzma", downloadProgressCallback, "GET");
+
+            let result = (await wlzma.decode(compressed.response)).toUint8Array();
+
+            return result;
+        }
+    }
+
+    return new Uint8Array((await XMLHttpRequestPromise(url, progressCallback, "GET")).response);
+}

--- a/Browser_IDE/languageDefinitions.js
+++ b/Browser_IDE/languageDefinitions.js
@@ -58,6 +58,9 @@ let SplashKitOnlineLanguageDefinitions = [
                 "runtimes/cxx/bin/SplashKitBackendWASMCPP.worker.js",
             ],
             compilerFiles: [
+                "external/js-lzma/src/wlzma.js",
+                "external/js-lzma/src/lzma.shim.js",
+                "downloadHandler.js",
                 "compilers/cxx/cxxCompiler.js",
             ],
             compilerName: "cxxCompiler",

--- a/Browser_IDE/splashKitOnlineEnvParams.js
+++ b/Browser_IDE/splashKitOnlineEnvParams.js
@@ -22,5 +22,6 @@ let SKO = (function(){
 
     return {
         language: getEnvParam("language", "JavaScript", false), /*don't decode, so + remains + rather than a space*/
+        useCompressedBinaries: getEnvParam("useCompressedBinaries", "on", true) == "on",
     };
 })();

--- a/SplashKitWasm/cmake/CMakeLists.txt
+++ b/SplashKitWasm/cmake/CMakeLists.txt
@@ -36,6 +36,8 @@ option(ENABLE_JS_BACKEND "Enable compiling SplashKit for use in SplashKit Online
 
 option(ENABLE_CPP_BACKEND "Enable compiling SplashKit for use in SplashKit Online C++ Projects" OFF)
 
+option(COMPRESS_BACKENDS "Enable LZMA compression of the backend files - good for releases" OFF)
+
 
 if (WIN32 OR MSYS OR MINGW)
   SET(MSYS "true")
@@ -365,7 +367,7 @@ if (EMSCRIPTEN)
         set_target_properties(SplashKitBackendWASMCPP PROPERTIES SUFFIX ".js")
 
         # Patch generated JavaScript runtime
-        add_custom_target( SplashKitBackendWASMCPPPatched ALL DEPENDS SplashKitBackendWASMCPP "${SK_WASMEXT}/out/wasm_cpplib_patched/SplashKitBackendWASMCPP.worker.js" "${SK_WASMEXT}/out/wasm_cpplib_patched/SplashKitBackendWASMCPP.js")
+        add_custom_target( SplashKitBackendWASMCPPPatched ALL DEPENDS SplashKitBackendWASMCPP "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.worker.js" "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.js")
 
         add_custom_command(
             DEPENDS
@@ -373,46 +375,114 @@ if (EMSCRIPTEN)
                 "${SK_WASMEXT}/out/wasm_cpplib/SplashKitBackendWASMCPP.worker.js"
                 "${SK_WASMEXT}/tools/cxx_backend_emscripten_glue_patcher.py"
             OUTPUT
-                "${SK_WASMEXT}/out/wasm_cpplib_patched/SplashKitBackendWASMCPP.worker.js"
-                "${SK_WASMEXT}/out/wasm_cpplib_patched/SplashKitBackendWASMCPP.js"
+                "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.worker.js"
+                "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.js"
             COMMENT "Patching generated Emscripten glue JavaScript for C++ Backend..."
-            COMMAND ${CMAKE_COMMAND} -E make_directory "${SK_WASMEXT}/out/wasm_cpplib_patched/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${SK_WASMEXT}/out/cxx/runtime/"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${SK_WASMEXT}/out/cxx/compiler/"
             COMMAND python "${SK_WASMEXT}/tools/cxx_backend_emscripten_glue_patcher.py"
                 "${SK_WASMEXT}/out/wasm_cpplib/SplashKitBackendWASMCPP.worker.js"
-                "${SK_WASMEXT}/out/wasm_cpplib_patched/SplashKitBackendWASMCPP.worker.js"
+                "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.worker.js"
                 "${SK_WASMEXT}/out/wasm_cpplib/SplashKitBackendWASMCPP.js"
-                "${SK_WASMEXT}/out/wasm_cpplib_patched/SplashKitBackendWASMCPP.js"
+                "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.js"
             )
 
         # Generate compilation system root files
-        add_custom_target( CPPCompilationSystemRoot ALL DEPENDS SplashKitBackendWASM "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip")
+        add_custom_target( CPPCompilationSystemRoot ALL DEPENDS SplashKitBackendWASM "${SK_OUT}/cxx/compiler/wasi-sysroot.zip")
+
+        if (COMPRESS_BACKENDS)
+            set(ZIP_COMPRESSION_FLAG "stored") #make the zip easily compressible later
+        else()
+            set(ZIP_COMPRESSION_FLAG "compressed")
+        endif()
 
         add_custom_command(
             DEPENDS
-                "${SK_WASMEXT}/prebuilt/sysroot.zip"
+                "${SK_WASMEXT}/prebuilt/cxx/compiler/sysroot.zip"
                 "${SK_WASMEXT}/tools/cxx_backend_systemroot_builder.py"
                 SplashKitBackendWASM
             OUTPUT
-                "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip"
+                "${SK_OUT}/cxx/compiler/wasi-sysroot.zip"
             COMMENT "Bundling C++ Compilation System Root..."
             COMMAND python "${SK_WASMEXT}/tools/cxx_backend_systemroot_builder.py"
                 $<TARGET_FILE:SplashKitBackend>
                 "${SK_SRC}/coresdk/"
-                "${SK_WASMEXT}/prebuilt/sysroot.zip"
-                "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip"
+                "${SK_WASMEXT}/prebuilt/cxx/compiler/sysroot.zip"
+                "${SK_OUT}/cxx/compiler/wasi-sysroot.zip"
+                ${ZIP_COMPRESSION_FLAG}
             )
 
+        # RUNTIME FILES
+        set(UNCOMPRESSED_RUNTIME_FILES
+            "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.js"
+            "${SK_WASMEXT}/out/cxx/runtime/SplashKitBackendWASMCPP.worker.js"
+        )
+
+        # COMPILER Root FILES
+        set(UNCOMPRESSED_COMPILER_ROOT_FILES
+            "${SK_WASMEXT}/out/cxx/compiler/wasi-sysroot.zip"
+        )
+
+        # COMPILER FILES
+        set(UNCOMPRESSED_COMPILER_SCRIPT_FILES
+            "${SK_WASMEXT}/prebuilt/cxx/compiler/clang++.js"
+            "${SK_WASMEXT}/prebuilt/cxx/compiler/wasm-ld.js"
+        )
+
+        # COMPILER FILES
+        set(UNCOMPRESSED_COMPILER_BINARY_FILES
+            "${SK_WASMEXT}/prebuilt/cxx/compiler/clang.wasm"
+            "${SK_WASMEXT}/prebuilt/cxx/compiler/lld.wasm"
+            "${SK_WASMEXT}/prebuilt/cxx/compiler/lld.data"
+        )
+
+        if (COMPRESS_BACKENDS)
+            set(COMPRESSED_COMPILER_ROOT_FILES ${UNCOMPRESSED_COMPILER_ROOT_FILES})
+            list(TRANSFORM COMPRESSED_COMPILER_ROOT_FILES APPEND ".lzma")
+
+            set(COMPRESSED_COMPILER_BINARY_FILES ${UNCOMPRESSED_COMPILER_BINARY_FILES})
+            list(TRANSFORM COMPRESSED_COMPILER_BINARY_FILES APPEND ".lzma")
+            list(TRANSFORM COMPRESSED_COMPILER_BINARY_FILES REPLACE "/prebuilt/" "/out/")
+
+            # Compress compilation system root files
+            add_custom_command(
+                DEPENDS ${UNCOMPRESSED_COMPILER_ROOT_FILES} "${SK_WASMEXT}/tools/backend_binary_compressor.py"
+                OUTPUT ${COMPRESSED_COMPILER_ROOT_FILES}
+                COMMENT "Compressing C++ Compiler Root Files..."
+                COMMAND python "${SK_WASMEXT}/tools/backend_binary_compressor.py" ${UNCOMPRESSED_COMPILER_ROOT_FILES} ${COMPRESSED_COMPILER_ROOT_FILES}
+            )
+
+            # Compress compiler binaries
+            add_custom_command(
+                DEPENDS ${UNCOMPRESSED_COMPILER_BINARY_FILES} "${SK_WASMEXT}/tools/backend_binary_compressor.py"
+                OUTPUT ${COMPRESSED_COMPILER_BINARY_FILES}
+                COMMENT "Compressing C++ Compiler Binaries..."
+                COMMAND python "${SK_WASMEXT}/tools/backend_binary_compressor.py" ${UNCOMPRESSED_COMPILER_BINARY_FILES} ${COMPRESSED_COMPILER_BINARY_FILES}
+            )
+
+            set(CXX_RUNTIME_FILES ${UNCOMPRESSED_RUNTIME_FILES})
+            set(CXX_COMPILER_FILES ${UNCOMPRESSED_COMPILER_SCRIPT_FILES} ${COMPRESSED_COMPILER_BINARY_FILES} ${COMPRESSED_COMPILER_ROOT_FILES})
+        else()
+            set(CXX_RUNTIME_FILES ${UNCOMPRESSED_RUNTIME_FILES})
+            set(CXX_COMPILER_FILES ${UNCOMPRESSED_COMPILER_SCRIPT_FILES} ${UNCOMPRESSED_COMPILER_BINARY_FILES} ${UNCOMPRESSED_COMPILER_ROOT_FILES})
+        endif()
 
         # Copy built library to the IDE
-        add_custom_target( SplashKitOnlineIDE_CPPBackend ALL DEPENDS SplashKitBackendWASMCPPPatched CPPCompilationSystemRoot)
+        add_custom_target( SplashKitOnlineIDE_CPPBackend ALL DEPENDS SplashKitBackendWASMCPPPatched CPPCompilationSystemRoot ${CXX_RUNTIME_FILES} ${CXX_COMPILER_FILES})
+
         add_custom_command(TARGET SplashKitOnlineIDE_CPPBackend
             POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E make_directory "${SK_BROWSERIDE}/runtimes/cxx/bin"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${SK_BROWSERIDE}/compilers/cxx/bin"
-            COMMAND ${CMAKE_COMMAND} -E copy "${SK_OUT}/wasm_cpplib_patched/SplashKitBackendWASMCPP.js" "${SK_BROWSERIDE}/runtimes/cxx/bin/SplashKitBackendWASMCPP.js"
-            COMMAND ${CMAKE_COMMAND} -E copy "${SK_OUT}/wasm_cpplib_patched/SplashKitBackendWASMCPP.worker.js" "${SK_BROWSERIDE}/runtimes/cxx/bin/SplashKitBackendWASMCPP.worker.js"
-            COMMAND ${CMAKE_COMMAND} -E copy "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip" "${SK_BROWSERIDE}/compilers/cxx/bin/wasi-sysroot.zip"
         )
+
+        foreach(current_file IN LISTS CXX_RUNTIME_FILES)
+            add_custom_command(TARGET SplashKitOnlineIDE_CPPBackend POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${current_file} "${SK_BROWSERIDE}/runtimes/cxx/bin/" COMMENT "Copying file: ${current_file}")
+        endforeach()
+
+        foreach(current_file IN LISTS CXX_COMPILER_FILES)
+            add_custom_command(TARGET SplashKitOnlineIDE_CPPBackend POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy ${current_file} "${SK_BROWSERIDE}/compilers/cxx/bin/" COMMENT "Copying file: ${current_file}")
+        endforeach()
 
         add_custom_command(TARGET SplashKitOnlineIDE_CPPBackend POST_BUILD
                        COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan

--- a/SplashKitWasm/cmake/CMakeLists.txt
+++ b/SplashKitWasm/cmake/CMakeLists.txt
@@ -433,7 +433,6 @@ if (EMSCRIPTEN)
         set(UNCOMPRESSED_COMPILER_BINARY_FILES
             "${SK_WASMEXT}/prebuilt/cxx/compiler/clang.wasm"
             "${SK_WASMEXT}/prebuilt/cxx/compiler/lld.wasm"
-            "${SK_WASMEXT}/prebuilt/cxx/compiler/lld.data"
         )
 
         if (COMPRESS_BACKENDS)

--- a/SplashKitWasm/tools/backend_binary_compressor.py
+++ b/SplashKitWasm/tools/backend_binary_compressor.py
@@ -1,0 +1,25 @@
+'''
+Takes two equal length lists of files.
+Compresses the files in the first list, and outputs them
+with the names in the second list.
+'''
+import sys
+import lzma
+
+file_list = sys.argv[1:]
+assert len(file_list)%2 == 0, "Non even number of files passed to binary compressor - there should be two equal length sets of files, the uncompressed and compressed names."
+
+file_count = len(file_list)//2;
+# split files into two halves, then zip them together
+files = zip(file_list[:file_count], file_list[file_count:])
+
+for filename_in, filename_out in files:
+    print("Compressing "+filename_in[filename_in.rfind("/"):]+"...")
+    try:
+        with open(filename_in, 'rb') as f:
+            file_contents = f.read()
+    except:
+        sys.exit("\033[91mFailed to read in file to compress at "+filename_in+"\033[0m")
+
+    with lzma.open(filename_out, "w", format=lzma.FORMAT_ALONE) as f:
+        f.write(file_contents)


### PR DESCRIPTION
# Description

This PR adds the ability to compress C++ binaries as part of the build process, and have those compressed binaries be read and decompressed client side. This has two effects:
1. Way faster loading over networks. When testing with Firefox's 'Wi-Fi' throttle setting, without this PR it takes a bit over a minute, while with it it takes 20 seconds. The difference will only be more dramatic on slower networks.
2. We can now store the binaries on GitHub! This is important so we can keep hosting it on here, at least for now.

When downloading files, it first checks if a file with the same name + '.lzma' exists on the server, and if so attempts to download and decompress that. If it doesn't exist, it falls back to downloading the normal file (and assumes it exists).

This PR also makes the compiler loading a bit more asynchronous, which speeds it up in general even if not using compressed binaries. It only currently compresses the C++ compiler binaries, as these are huge and take the bulk of the loading time. The same system can be used to compress remaining files, though I would recommend against it as the GZIP compression offered by web servers should be enough.


Pre-built files can be found [here](https://github.com/WhyPenguins/SplashkitOnline/tree/binary-compression-binaries/Browser_IDE/compilers/cxx/bin), and [here](https://github.com/WhyPenguins/SplashkitOnline/tree/binary-compression-binaries/Browser_IDE/runtimes/cxx/bin)
And pre-built files for compiling/bundling SplashKit Online can be found [here](https://github.com/WhyPenguins/SplashkitOnline/tree/binary-compression-binaries/SplashKitWasm/prebuilt/cxx/compiler)
Any files with 'extract_here' in the name will need to be extracted.


Note: when working locally, using compressed binaries actually _increases_ load times slightly, due to the decompression overhead - it adds about 4 seconds. Because of this, there's also now a  `useCompressedBinaries` environment parameter, for example `http://localhost:8000/?language=C++&useCompressedBinaries=off`. This is recommended when developing locally.



## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
 - The build process has been run a few times to ensure compression happens when enabled (and doesn't when not). 
 - SplashKit Online has been loaded and files compiled, and it's been checked that its using the compressed binaries in the network tab.
 - It's been checked that if the compressed binaries are missing, it uses the uncompressed ones instead.
 - The new environment parameter `useCompressedBinaries` has also been tested similarly.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
