### PR TITLE
Add support for audio in C++ runtime

### DIFF
--- a/Browser_IDE/compilers/cxx/cxxCompilerClangBackend.js
+++ b/Browser_IDE/compilers/cxx/cxxCompilerClangBackend.js
@@ -159,9 +159,9 @@ export const linkObjects = async (objects) => {
                 '-lsockets',
                 '--no-entry',
 
+                '--wrap=_ZN13splashkit_lib14process_eventsEv',
                 '-lSplashKitBackend',
 
-                //'main.o',
                 '-o',
                 'main.wasm',
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The SplashKit API has been exposed to the global scope of Javascript, allowing t
 The SplashKit library handles all input, graphics, audio and file handling, and is invoked by the user's Javascript. The library has been compiled into a WebAssembly (Wasm) module via Emscripten. This module is loaded into the page as soon as the IDE starts, and the functions in it exported as Javascript functions.
 
 # Experimental C++ Support
-It is also possible to use C++ within SplashKit Online! This is still experimental, and as such certain features such as audio don't work yet. However, the majority of graphics and input functionality works, and you can still use it to compile and test regular C++ programs too!
+It is also possible to use C++ within SplashKit Online! This is still experimental, and as such is missing some features and can be a bit unstable. However, the majority of graphics, audio, and input functionality works, and you can use it to compile and test regular C++ programs too!
 
 Assuming the IDE is set up correctly, installation of the C++ side involves three more steps:
 

--- a/SplashKitWasm/cmake/CMakeLists.txt
+++ b/SplashKitWasm/cmake/CMakeLists.txt
@@ -230,8 +230,14 @@ add_definitions(-DELPP_THREAD_SAFE)
 #### END SETUP ####
 #### SplashKitBackend STATIC LIBRARY ####
 add_library(SplashKitBackend STATIC ${SOURCE_FILES} ${INCLUDE_FILES})
+#### SplashKitBackendCXX STATIC LIBRARY ####
+# IMPORTANT NOTE: This library does _not _ get linked anywhere in this file.
+# Instead, it is linked only during in-browser compilation.
+# It will not link without specific linker parameters (i.e --wrap=_ZN13splashkit_lib14process_eventsEv)
+add_library(SplashKitBackendCXX STATIC "${SK_WASMEXT}/src/cxxbackend/patched_functions.cpp" ${SOURCE_FILES} ${INCLUDE_FILES})
 
 target_link_libraries(SplashKitBackend ${LIB_FLAGS})
+target_link_libraries(SplashKitBackendCXX ${LIB_FLAGS})
 
 if (EMSCRIPTEN)
     # Ensure the 'generated' folder exists
@@ -326,6 +332,10 @@ set_target_properties(SplashKitBackend
     PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${SK_OUT}/lib"
 )
+set_target_properties(SplashKitBackendCXX
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${SK_OUT}/lib"
+)
 
 #### END SplashKitBackend STATIC LIBRARY ####
 #### SplashKitBackend WASM LIBRARY ####
@@ -333,7 +343,7 @@ if (EMSCRIPTEN)
     if (ENABLE_JS_BACKEND)
         add_executable(SplashKitBackendWASM "${SK_WASMEXT}/generated/SplashKitWasmGlue.cpp")
         set_target_properties(SplashKitBackendWASM PROPERTIES LINK_FLAGS "-sALLOW_TABLE_GROWTH -s MAXIMUM_MEMORY=1gb -sALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=addFunction -s EXPORTED_FUNCTIONS=\"['_malloc','stackAlloc','stackSave','stackRestore','_free']\" -s EXPORT_ALL=1 -sFS_DEBUG --post-js ${SK_WASMEXT}/generated/SplashKitWasmGlue.js")
-        target_link_libraries(SplashKitBackendWASM SplashKitBackend)
+        target_link_libraries(SplashKitBackendWASM SplashKitBackend) #NOTE: deliberately using SplashKitBackend rather than SplashKitBackendCXX - we don't care about the final linked output, we just want Emscripten to give us its JS runtime
         set_target_properties(SplashKitBackendWASM
             PROPERTIES
             RUNTIME_OUTPUT_DIRECTORY "${SK_OUT}/wasmlib_javascript"
@@ -385,18 +395,18 @@ if (EMSCRIPTEN)
             )
 
         # Generate compilation system root files
-        add_custom_target( CPPCompilationSystemRoot ALL DEPENDS SplashKitBackendWASM "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip")
+        add_custom_target( CPPCompilationSystemRoot ALL DEPENDS SplashKitBackendCXX "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip")
 
         add_custom_command(
             DEPENDS
                 "${SK_WASMEXT}/prebuilt/sysroot.zip"
                 "${SK_WASMEXT}/tools/cxx_backend_systemroot_builder.py"
-                SplashKitBackendWASM
+                SplashKitBackendCXX
             OUTPUT
                 "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip"
             COMMENT "Bundling C++ Compilation System Root..."
             COMMAND python "${SK_WASMEXT}/tools/cxx_backend_systemroot_builder.py"
-                $<TARGET_FILE:SplashKitBackend>
+                $<TARGET_FILE:SplashKitBackendCXX>
                 "${SK_SRC}/coresdk/"
                 "${SK_WASMEXT}/prebuilt/sysroot.zip"
                 "${SK_OUT}/wasm_cpplib_patched/wasi-sysroot.zip"

--- a/SplashKitWasm/src/cxxbackend/patched_functions.cpp
+++ b/SplashKitWasm/src/cxxbackend/patched_functions.cpp
@@ -1,0 +1,16 @@
+// SplashKit functions patched using ld wrap
+// Hopefully the mangled names don't change - if they do,
+// this will need to be updated.
+
+extern "C"
+{
+    // patch process_events()
+    void __sko_process_events();
+    void __real__ZN13splashkit_lib14process_eventsEv();
+
+    void __wrap__ZN13splashkit_lib14process_eventsEv()
+    {
+        __sko_process_events(); // receive events from outside world and pass into SDL
+        __real__ZN13splashkit_lib14process_eventsEv();
+    }
+}

--- a/SplashKitWasm/tools/cxx_backend_systemroot_builder.py
+++ b/SplashKitWasm/tools/cxx_backend_systemroot_builder.py
@@ -42,7 +42,6 @@ with io.BytesIO() as new_zip_buffer:
 
         for file in os.listdir(splashkit_includes_path):
             if ".h" in file and 'raspi_gpio' not in file:
-                #shutil.copy(splashkit_includes_path+file, splashkit_sysroot_includes_path)
                 copy_in_file(new_zip, splashkit_includes_path+file, splashkit_sysroot_includes_path+file);
 
                 global_header += "#include \"splashkit/"+file+"\"\n"
@@ -50,18 +49,6 @@ with io.BytesIO() as new_zip_buffer:
         global_header += """
         // mimic namespacelessness of normal SplashKit Clib-based C++ version
         using namespace splashkit_lib;
-
-        // patch process_events() to receive events from outside world first.
-        // Ideally we'd patch process_events itself, but this allows us to use the same
-        // base library for the C++ and JavaScript backend. Maybe if the JavaScript backend
-        // switches to a WebWorker architecture too, then we can replace this
-        // while keeping everything unified.
-        extern "C" void __sko_process_events();
-        extern "C" inline void _process_events() {
-            __sko_process_events(); // receive events from outside world and pass into SDL
-            process_events(); // normal SplashKit process_events()
-        }
-        #define process_events() _process_events()
         """
 
         new_zip.writestr("include/splashkit.h", global_header)


### PR DESCRIPTION
# Description

This PR adds support for audio to the C++ runtime. Until now it's just used a shim for the `AudioContext`, which is inaccessible to the WebWorker running the user's program, so that it could still execute without aborting. The shim however didn't _do_ anything.

Now the shim records information from the program regarding its audio output, and separately in `__sk_process_events()` new audio is fetched from the program and sent back to the execution environment page, where it gets buffered then played.

For reviewers:
This PR is dependent on #73, and is based on those commits - if changes are needed there I'll rebase. I've made a temporary branch for that PR and based this one off it, so the 'Files Changed' and 'Commits' on this PR should be specific to the audio works.

One thing I'm unsure about in this PR is the way audio is fetched and buffered. It works, but I do notice sometimes the audio can run behind the program by a few hundred milliseconds (a noticeable delay). I've found for some reason that increasing the size of the buffer on the main page helps here, but suspect this really points to a logic error somewhere.

Pre-built binaries are the same as the current main, with the addition of the changes here: https://github.com/WhyPenguins/SplashkitOnline/commit/79d0eae7d7bc5754b6c8822253a70dc63434b1e3

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (update or new)

## How Has This Been Tested?

Cave Escape has been tested and audio works. The responsiveness has also been tested, by making the audio start/stop on game start/reset. 

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
