### PR TITLE
Add support for stdin in C++ language backend

### DIFF
--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -29,7 +29,7 @@
 			<div class="sk-contents">
 				<div id="output" class="sk-contents sk-contents-darker sk-terminal"></div>
 				<div class="sk-terminal-input-wrapper">
-					<span style="color: #CCC">&gt;</span>
+					<span style="color: #CCC">&gt; </span>
 					<input type="text" id="terminal-input" />
 				</div>
 			</div>

--- a/Browser_IDE/executionEnvironment.html
+++ b/Browser_IDE/executionEnvironment.html
@@ -28,6 +28,10 @@
 			</div>
 			<div class="sk-contents">
 				<div id="output" class="sk-contents sk-contents-darker sk-terminal"></div>
+				<div class="sk-terminal-input-wrapper">
+					<span style="color: #CCC">&gt;</span>
+					<input type="text" id="terminal-input" />
+				</div>
 			</div>
 		</div>
 	</div>

--- a/Browser_IDE/runtimes/cxx/cxxRuntime.js
+++ b/Browser_IDE/runtimes/cxx/cxxRuntime.js
@@ -40,6 +40,9 @@ var Module = {
             case "ProgramContinued":
                 executionEnvironment.signalContinue();
                 break;
+            case "stdinAwait":
+                setTerminalInputAwaitState(true);
+                break;
         }
     }
 };
@@ -78,6 +81,8 @@ class ExecutionEnvironmentInternalCXX extends ExecutionEnvironmentInternal{
                 }, 100);
             });
         }
+
+        setTerminalInputAwaitState(false);
     }
     async runProgram(program){
         await this.stopProgram();
@@ -85,6 +90,8 @@ class ExecutionEnvironmentInternalCXX extends ExecutionEnvironmentInternal{
 
         clearInterval(this.keepAliveID);
         this.keepAliveID = setInterval(this.sendKeepAliveSignal, 500);
+
+        setTerminalInputAwaitState(false);
 
         RunProgram(program);
     }
@@ -162,9 +169,20 @@ new ResizeObserver(function(){
 
 // send terminal input on enter
 let terminalInput = document.getElementById("terminal-input");
+
+function setTerminalInputAwaitState(awaiting) {
+    if (awaiting)
+        terminalInput.placeholder = 'awaiting input...';
+    else
+        terminalInput.placeholder = '';
+}
+
 terminalInput.addEventListener("keydown", function(event){
     if (event.key === "Enter") {
         writeTerminal("> " + terminalInput.value);
+        sendWorkerCommand("stdin", {value: terminalInput.value + '\n'});
+
         terminalInput.value = '';
+        setTerminalInputAwaitState(false);
     }
 });

--- a/Browser_IDE/runtimes/cxx/cxxRuntime.js
+++ b/Browser_IDE/runtimes/cxx/cxxRuntime.js
@@ -159,3 +159,12 @@ new ResizeObserver(function(){
     if (window.cloneObject != undefined)
         sendWorkerCommand("EmEvent", { target: 'canvas', boundingClientRect: cloneObject(Module.canvas.getBoundingClientRect()) });
 }).observe(Module.canvas);
+
+// send terminal input on enter
+let terminalInput = document.getElementById("terminal-input");
+terminalInput.addEventListener("keydown", function(event){
+    if (event.key === "Enter") {
+        writeTerminal("> " + terminalInput.value);
+        terminalInput.value = '';
+    }
+});

--- a/Browser_IDE/runtimes/cxx/workerEventProcessor.js
+++ b/Browser_IDE/runtimes/cxx/workerEventProcessor.js
@@ -24,6 +24,12 @@ function handleEvent([event, args]){
         case "keepAlive":
             lastKeepAlive = performance.now();
             break;
+        case "stdin":
+            Module.intArrayFromString(args.value).forEach(function(v) {inputBuffer.push(v)});
+            inputBuffer.push(null);
+            break;
+        case "continue":
+            break;
         case "EmEvent":
             switch (args.target) {
                 case 'document': {
@@ -103,10 +109,14 @@ function __sko_process_events(){
 }
 
 // a busy loop for when paused
-function pauseLoop(waitOn, reportContinue=true) {
+function pauseLoop(waitOn, reportContinue=true, handleEvents=true) {
     let paused = true;
     while (paused) {
         let programEvents = fetchEvents();
+        if (handleEvents) {
+            programEvents.forEach(handleEvent);
+        }
+
         for (let i = 0; i < programEvents.length; i ++) {
             if (programEvents[i][0] == waitOn) {
                 lastKeepAlive = performance.now();
@@ -130,6 +140,21 @@ Module['onExit'] = function() {
     postCustomMessage({
         type: "ProgramEnded"
     });
+}
+
+let inputBuffer = new Array(0);
+let inputBufferWasFull = false;
+
+Module['stdin'] = function() {
+    if (inputBuffer.length == 0) {
+        postCustomMessage({ type: "stdinAwait" });
+
+        pauseLoop('stdin', false, true);
+    }
+
+    let character = inputBuffer.splice(0, 1);
+
+    return character[0];
 }
 
 // Clear event buffer

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -265,16 +265,22 @@ textarea {
     border:0;
     padding-left:1em;
     resize: none;
-    font-family:monospace, serif;
+    font-family: monospace, serif;
     white-space: pre-wrap;
     background-color: #161616;
 }
 
+.sk-terminal > :nth-child(2) {
+    margin-top: auto !important;
+}
+
 .sk-terminal-input-wrapper {
-    padding:0 10px;
+    padding: 0 1em;
     overflow: hidden;
     box-shadow: 4px 4px 10px rgba(0,0,0,0.3) inset;
     display: flex;
+    font-family: monospace, serif;
+    white-space: pre-wrap;
 }
 .sk-terminal-input-wrapper input {
     flex-grow: 1;

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -284,6 +284,8 @@ textarea {
 }
 .sk-terminal-input-wrapper input {
     flex-grow: 1;
+    margin: 0;
+    padding: 0;
 }
 
 .node{

--- a/Browser_IDE/stylesheet.css
+++ b/Browser_IDE/stylesheet.css
@@ -78,6 +78,15 @@ select:hover {
     background-color: #303030;
 }
 
+input {
+    margin: 0px 3px;
+    border-radius: 3px;
+    border: 0;
+    background-color: transparent;
+    color: inherit;
+    outline:none;
+    line-height: 1em;
+}
 
 a:visited {
     color: #0A0;
@@ -181,6 +190,7 @@ a:visited {
     flex-direction: column;
     flex-grow:1;
     color: white;
+    min-height: 0;
 }
 .sk-contents-darker {
     background-color: #1B1B1B;
@@ -258,6 +268,16 @@ textarea {
     font-family:monospace, serif;
     white-space: pre-wrap;
     background-color: #161616;
+}
+
+.sk-terminal-input-wrapper {
+    padding:0 10px;
+    overflow: hidden;
+    box-shadow: 4px 4px 10px rgba(0,0,0,0.3) inset;
+    display: flex;
+}
+.sk-terminal-input-wrapper input {
+    flex-grow: 1;
 }
 
 .node{


### PR DESCRIPTION
# Description

This PR allows usage of `read_line` and other functions relying on `stdin`. It also adds a styled input box for entering text. Now it is possible to write terminal applications in SplashKit Online.

![terminal](https://github.com/thoth-tech/SplashkitOnline/assets/42032199/f9bc7dc9-3be6-462e-9437-5aa4759c8bc1)


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

`read_line` has been tested (see above gif) - also tried `std::cin` and that works too.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox
- [x] Tested in latest Edge

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
