### PR TITLE
Fix scrollbar position

### DIFF
--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -425,8 +425,8 @@ function SwitchToTab(editor){
 
     for (let i = 0; i < editors.length; i ++) {
         // Before refreshing the editor, get the scroll position of the editor window
-        let display = currentEditor.display;
-        let scrollTop = display.scrollbar.scrollTop;
+        let display = currentEditor.editor.display;
+        let scrollTop = display.scroller.scrollTop;
         // Refresh the editor
         editors[i].editor.refresh();
         // Update the scrollbar with the original scrollbar position

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -424,7 +424,13 @@ function SwitchToTab(editor){
     }
 
     for (let i = 0; i < editors.length; i ++) {
+        // Before refreshing the editor, get the scroll position of the editor window
+        let display = currentEditor.display;
+        let scrollTop = display.scrollbar.scrollTop;
+        // Refresh the editor
         editors[i].editor.refresh();
+        // Update the scrollbar with the original scrollbar position
+        display.scrollbars.setScrollTop(scrollTop);
     }
 }
 


### PR DESCRIPTION
# Description

Fixed the scrollbar bug that was causing the scrollbar to be in the incorrect position when changing between files in the editor.

Fixes # Fix scrollbar jumping to top when switching code files

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Tested with multiple machines on multiple browsers. Specifically a windows and mac machine. On Firefox, Edge, Chrome, Safari.

## Testing Checklist

- [X] Tested in latest Chrome
- [X] Tested in latest Safari
- [X] Tested in latest Firefox

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
