### PR TITLE
Feature audio message

### DIFF
--- a/Browser_IDE/IDEStartupMain.js
+++ b/Browser_IDE/IDEStartupMain.js
@@ -60,3 +60,6 @@ async function StartIDE() {
 }
 
 StartIDE();
+
+// Focus the window, this is used in order to detect if the user clicks inside the iFrame containing the program
+window.focus();

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -684,6 +684,62 @@ function getCurrentCompiler() {
     return currentCompiler;
 }
 
+
+let audioFunctionNotificationOnce = false;
+
+function audioFunctionNotification(files) {
+    if (!audioFunctionNotificationOnce) {
+        // Audio functions
+        let audioFunctions = [
+            "audio_ready",
+            "close_audio",
+            "open_audio",
+            "fade_music_in",
+            "fade_music_out",
+            "free_all_music",
+            "free_music",
+            "has_music",
+            "load_music",
+            "music_filename",
+            "music_name",
+            "music_named",
+            "music_playing",
+            "music_volume",
+            "pause_music",
+            "play_music",
+            "resume_music",
+            "set_music_volume",
+            "stop_music",
+            "fade_all_sound_effects_out",
+            "fade_sound_effect_out",
+            "free_all_sound_effects",
+            "free_sound_effect",
+            "has_sound_effect",
+            "load_sound_effect",
+            "play_sound_effect",
+            "play_sound_effect_named_with_volume",
+            "play_sound_effect_named_with_times",
+            "play_sound_effect_with_volume",
+            "play_sound_effect_with_times",
+            "sound_effect_filename",
+            "sound_effect_name",
+            "sound_effect_named",
+            "sound_effect_playing",
+            "stop_sound_effect"
+        ];
+
+        // Check if any audio functions are present in the source code
+        let audioFunctionFound = files.some(file => 
+            audioFunctions.some(func => file.source.includes(func))
+        );
+
+        if (audioFunctionFound) displayEditorNotification("Audio functions are present in the code! To hear audio click into the window.", NotificationIcons.WARNING, 10);
+
+        // Set the flag to true, so the notification is only shown once
+        audioFunctionNotificationOnce = true;
+    }
+}
+
 // Functions to run/pause/continue/stop/restart the program itself
 async function runProgram(){
     try {
@@ -717,6 +773,7 @@ async function runProgram(){
         let compiled = await currentCompiler.compileAll(await Promise.all(compilableFiles.map(mapBit)), await Promise.all(sourceFiles.map(mapBit)), reportCompilationError);
 
         if (compiled.output != null) {
+            audioFunctionNotification(compiled.output);
             executionEnviroment.runProgram(compiled.output);
         } else {
             displayEditorNotification("Project has errors! Please see terminal for details.", NotificationIcons.ERROR);

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -687,7 +687,7 @@ function getCurrentCompiler() {
 
 let audioFunctionNotificationOnce = false;
 
-function audioFunctionNotification(files) {
+function audioFunctionNotification(source) {
     if (!audioFunctionNotificationOnce) {
         // Audio functions
         let audioFunctions = [
@@ -729,11 +729,9 @@ function audioFunctionNotification(files) {
         ];
 
         // Check if any audio functions are present in the source code
-        let audioFunctionFound = files.some(file => 
-            audioFunctions.some(func => file.source.includes(func))
-        );
+        let audioFunctionFound = audioFunctions.some(func => source.includes(func));
 
-        if (audioFunctionFound) displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, 10);
+        if (audioFunctionFound) displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, -1);
 
         // Set the flag to true, so the notification is only shown once
         audioFunctionNotificationOnce = true;
@@ -755,6 +753,7 @@ async function runProgram(){
 
         async function mapBit(filename){
             let source = await fileAsString(await storedProject.access((project) => project.readFile(filename)));
+            audioFunctionNotification(source);
             return {
                 name: filename,
                 source: source
@@ -773,7 +772,6 @@ async function runProgram(){
         let compiled = await currentCompiler.compileAll(await Promise.all(compilableFiles.map(mapBit)), await Promise.all(sourceFiles.map(mapBit)), reportCompilationError);
 
         if (compiled.output != null) {
-            audioFunctionNotification(compiled.output);
             executionEnviroment.runProgram(compiled.output);
         } else {
             displayEditorNotification("Project has errors! Please see terminal for details.", NotificationIcons.ERROR);

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -729,9 +729,7 @@ function audioFunctionNotification(source) {
         ];
 
         // Check if any audio functions are present in the source code
-        let audioFunctionFound = audioFunctions.some(func => source.includes(func));
-
-        if (audioFunctionFound) displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, -1);
+        if (audioFunctions.some(func => source.includes(func))) displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, -1);
 
         // Set the flag to true, so the notification is only shown once
         audioFunctionNotificationOnce = true;

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -691,14 +691,16 @@ let audioNotification = null;
 // This is a hack to detect if the user has clicked into the iFrame
 // If they do, we set a flag to prevent the audio notification from showing and remove it if it's already showing
 // The timeout is to ensure that the activeElement is set correctly, essentially we're telling the browser to wait one tick before checking
-window.addEventListener("blur", () => {
-  setTimeout(() => {
-    if (document.activeElement.id === "iframetest") {
-      audioNotificationRunOnce = true;
-      if (audioNotification != null) audioNotification.deleteNotification();
-    }
-  });
-});
+if (SKO.language == "C++") {
+    window.addEventListener("blur", () => {
+        setTimeout(() => {
+            if (document.activeElement.id == "iframetest") {
+                audioNotificationRunOnce = true;
+                if (audioNotification != null) audioNotification.deleteNotification();
+            }
+        });
+    });
+}
 
 function audioFunctionNotification(source) {
     // Audio functions
@@ -765,7 +767,7 @@ async function runProgram(){
 
         async function mapBit(filename){
             let source = await fileAsString(await storedProject.access((project) => project.readFile(filename)));
-            if (!audioNotificationRunOnce) audioNotification = audioFunctionNotification(source);
+            if (SKO.language == "C++" && !audioNotificationRunOnce) audioNotification = audioFunctionNotification(source);
             return {
                 name: filename,
                 source: source

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -733,7 +733,7 @@ function audioFunctionNotification(files) {
             audioFunctions.some(func => file.source.includes(func))
         );
 
-        if (audioFunctionFound) displayEditorNotification("Audio functions are present in the code! To hear audio click into the window.", NotificationIcons.WARNING, 10);
+        if (audioFunctionFound) displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, 10);
 
         // Set the flag to true, so the notification is only shown once
         audioFunctionNotificationOnce = true;

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -684,56 +684,70 @@ function getCurrentCompiler() {
     return currentCompiler;
 }
 
+// ------ Audio Notification ------
+let audioNotificationRunOnce = false;
+let audioNotification = null;
 
-let audioFunctionNotificationOnce = false;
+// This is a hack to detect if the user has clicked into the iFrame
+// If they do, we set a flag to prevent the audio notification from showing and remove it if it's already showing
+// The timeout is to ensure that the activeElement is set correctly, essentially we're telling the browser to wait one tick before checking
+window.addEventListener("blur", () => {
+  setTimeout(() => {
+    if (document.activeElement.id === "iframetest") {
+      audioNotificationRunOnce = true;
+      if (audioNotification != null) audioNotification.deleteNotification();
+    }
+  });
+});
 
 function audioFunctionNotification(source) {
-    if (!audioFunctionNotificationOnce) {
-        // Audio functions
-        let audioFunctions = [
-            "audio_ready",
-            "close_audio",
-            "open_audio",
-            "fade_music_in",
-            "fade_music_out",
-            "free_all_music",
-            "free_music",
-            "has_music",
-            "load_music",
-            "music_filename",
-            "music_name",
-            "music_named",
-            "music_playing",
-            "music_volume",
-            "pause_music",
-            "play_music",
-            "resume_music",
-            "set_music_volume",
-            "stop_music",
-            "fade_all_sound_effects_out",
-            "fade_sound_effect_out",
-            "free_all_sound_effects",
-            "free_sound_effect",
-            "has_sound_effect",
-            "load_sound_effect",
-            "play_sound_effect",
-            "play_sound_effect_named_with_volume",
-            "play_sound_effect_named_with_times",
-            "play_sound_effect_with_volume",
-            "play_sound_effect_with_times",
-            "sound_effect_filename",
-            "sound_effect_name",
-            "sound_effect_named",
-            "sound_effect_playing",
-            "stop_sound_effect"
-        ];
+    // Audio functions
+    let audioFunctions = [
+        "audio_ready",
+        "close_audio",
+        "open_audio",
+        "fade_music_in",
+        "fade_music_out",
+        "free_all_music",
+        "free_music",
+        "has_music",
+        "load_music",
+        "music_filename",
+        "music_name",
+        "music_named",
+        "music_playing",
+        "music_volume",
+        "pause_music",
+        "play_music",
+        "resume_music",
+        "set_music_volume",
+        "stop_music",
+        "fade_all_sound_effects_out",
+        "fade_sound_effect_out",
+        "free_all_sound_effects",
+        "free_sound_effect",
+        "has_sound_effect",
+        "load_sound_effect",
+        "play_sound_effect",
+        "play_sound_effect_named_with_volume",
+        "play_sound_effect_named_with_times",
+        "play_sound_effect_with_volume",
+        "play_sound_effect_with_times",
+        "sound_effect_filename",
+        "sound_effect_name",
+        "sound_effect_named",
+        "sound_effect_playing",
+        "stop_sound_effect"
+    ];
 
-        // Check if any audio functions are present in the source code
-        if (audioFunctions.some(func => source.includes(func))) displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, -1);
-
-        // Set the flag to true, so the notification is only shown once
-        audioFunctionNotificationOnce = true;
+    // Check if any audio functions are present in the source code
+    if (audioFunctions.some(func => source.includes(func))) {
+        // Set flag to prevent the audio notification from showing again
+        audioNotificationRunOnce = true;
+        // Display notification and return it so that it can be globally accessed and removed if needed
+        return displayEditorNotification("Audio functions are present in the code! Please click into the window to hear audio.", NotificationIcons.WARNING, -1);
     }
+    return null;
 }
 
 // Functions to run/pause/continue/stop/restart the program itself
@@ -751,7 +765,7 @@ async function runProgram(){
 
         async function mapBit(filename){
             let source = await fileAsString(await storedProject.access((project) => project.readFile(filename)));
-            audioFunctionNotification(source);
+            if (!audioNotificationRunOnce) audioNotification = audioFunctionNotification(source);
             return {
                 name: filename,
                 source: source

--- a/Browser_IDE/notifications.js
+++ b/Browser_IDE/notifications.js
@@ -84,5 +84,8 @@ function displayEditorNotification(message, icon=NotificationIcons.NONE, timeout
         timeoutID = setTimeout(timeoutFunc, timeout * 1000);
     notificationsArea.appendChild(notification);
 
+    // attach the delete function to the notification element, that way it can be called externally
+    notification.deleteNotification = deleteNotification;
+
     return notification;
 }


### PR DESCRIPTION
# Description

Adds a notification that shows if the user hasn't clicked into the program iFrame window and SplashKit audio functions are being used. Essentially, it reminds the user to click into the Execution Environment so that they can hear the audio playing. This is only a problem on the C++ runtime.

Fixes # Show message to user requesting them to click into the Execution Environment iFrame to get audio working

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Tested in windows and mac

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
