### PR TITLE
Generate live previews for PRs, main and deployed

### DIFF
--- a/.github/workflows/generate_pr_map.py
+++ b/.github/workflows/generate_pr_map.py
@@ -41,7 +41,7 @@ def cache_root_hashes():
                 root_file_hashes[file_hash] = file_path
 
 def process_pr_folder(pr_folder, bulk_dir):
-    pr_path_map = {"redirects": {}}
+    pr_path_map = {"redirects": {}, "root": get_relative_path(pr_folder, ROOT_DIR)}
     for root, _, files in os.walk(pr_folder):
         for file in files:
             if os.path.splitext(file)[1].lower() in EXTENSIONS:

--- a/.github/workflows/generate_pr_map.py
+++ b/.github/workflows/generate_pr_map.py
@@ -34,6 +34,8 @@ def cache_root_hashes():
     for root, dirs, files in os.walk(ROOT_DIR, topdown=True):
         if "pr-previews" in dirs:
             del dirs[dirs.index("pr-previews")]
+        if "branch-previews" in dirs:
+            del dirs[dirs.index("branch-previews")]
         for file in files:
             if os.path.splitext(file)[1].lower() in EXTENSIONS:
                 file_path = os.path.join(root, file)
@@ -66,6 +68,10 @@ def process_pr_folder(pr_folder, bulk_dir):
                     if not os.path.exists(bulk_path):
                         shutil.move(file_path, bulk_path)
                         print("move", file_path, bulk_path)
+                    else:
+                        os.remove(file_path)
+                        print("exists, delete", file_path, bulk_path)
+
                     pr_path_map["redirects"][get_relative_path(file_path, ROOT_DIR)] = get_relative_path(bulk_path, ROOT_DIR)
 
     # Write the PR path map JSON

--- a/.github/workflows/generate_pr_map.py
+++ b/.github/workflows/generate_pr_map.py
@@ -1,0 +1,92 @@
+# Thanks ChatGPT! I was way too lazy to write this ahaha
+import os
+import hashlib
+import json
+import shutil
+
+# Define paths and extensions
+ROOT_DIR = "./"
+PR_DIRS = [os.path.join(ROOT_DIR, "pr-previews"), os.path.join(ROOT_DIR, "branch-previews")]
+PR_BULK_DIRS = [os.path.join(ROOT_DIR, "pr-previews/bulk"), os.path.join(ROOT_DIR, "branch-previews/bulk")]
+EXTENSIONS = {".wasm", ".lzma", ".zip"}
+
+# Ensure PRBulk directory exists
+for bulk_dir in PR_BULK_DIRS:
+    os.makedirs(bulk_dir, exist_ok=True)
+
+# Global cache for root file hashes
+root_file_hashes = {}
+
+def calculate_hash(filepath):
+    """Calculates SHA-256 hash of a file."""
+    sha256 = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+def get_relative_path(full_path, base_dir):
+    """Gets the relative path from the base directory."""
+    return "/" + os.path.relpath(full_path, base_dir).replace(os.sep, "/")
+
+def cache_root_hashes():
+    """Caches hashes of all files in the root directory with specified extensions."""
+    for root, dirs, files in os.walk(ROOT_DIR, topdown=True):
+        if "pr-previews" in dirs:
+            del dirs[dirs.index("pr-previews")]
+        for file in files:
+            if os.path.splitext(file)[1].lower() in EXTENSIONS:
+                file_path = os.path.join(root, file)
+                file_hash = calculate_hash(file_path)
+                root_file_hashes[file_hash] = file_path
+
+def process_pr_folder(pr_folder, bulk_dir):
+    pr_path_map = {"redirects": {}}
+    for root, _, files in os.walk(pr_folder):
+        for file in files:
+            if os.path.splitext(file)[1].lower() in EXTENSIONS:
+                file_path = os.path.join(root, file)
+                rel_path = get_relative_path(file_path, pr_folder)
+
+                # Calculate file hash
+                file_hash = calculate_hash(file_path)
+
+                if file_hash in root_file_hashes:
+                    # If an identical file exists in root, create a redirect and delete
+                    root_file_path = root_file_hashes[file_hash]
+                    pr_path_map["redirects"][get_relative_path(file_path, ROOT_DIR)] = get_relative_path(root_file_path, ROOT_DIR)
+                    os.remove(file_path)
+                    print("remove", file_path)
+                else:
+                    # Prepare to move file to PRBulk with hash-appended name if unique
+                    new_name = f"{os.path.splitext(file)[0]}_{file_hash}{os.path.splitext(file)[1]}"
+                    bulk_path = os.path.join(bulk_dir, new_name)
+
+                    # Move file to PRBulk if it doesn’t already exist
+                    if not os.path.exists(bulk_path):
+                        shutil.move(file_path, bulk_path)
+                        print("move", file_path, bulk_path)
+                    pr_path_map["redirects"][get_relative_path(file_path, ROOT_DIR)] = get_relative_path(bulk_path, ROOT_DIR)
+
+    # Write the PR path map JSON
+    pr_map_file = os.path.join(pr_folder, "PRPathMap.json")
+    with open(pr_map_file, "w") as json_file:
+        json.dump(pr_path_map, json_file, indent=4)
+
+# Cache root hashes once at the beginning
+cache_root_hashes()
+
+# Process each PR folder
+for pr_dir, bulk_dir in zip(PR_DIRS, PR_BULK_DIRS):
+    print(f"Processing {pr_dir}...")
+    if not os.path.exists(pr_dir):
+        print(f"!!!!!!{pr_dir} doesn't exist! Skipping!!!!!!")
+        continue
+
+    for pr_folder_name in os.listdir(pr_dir):
+        pr_folder_path = os.path.join(pr_dir, pr_folder_name)
+        if os.path.isdir(pr_folder_path) and pr_folder_path != bulk_dir:
+            print(f"Processing {pr_folder_path}...")
+            process_pr_folder(pr_folder_path, bulk_dir)
+
+print("Deduplication and mapping complete!")

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,6 +28,7 @@ jobs:
   # May be running untrusted code, so it's been given very restricted permissions
   # Hopefully it can't do anything too bad...
   build:
+    if: ${{ github.event_name != 'pull_request_target' || github.event.action != 'closed' }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -109,11 +110,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - name: Download a Build Artifact
+      - name: Download built site
+        if: ${{ github.event_name != 'pull_request_target' || github.event.action != 'closed' }}
         uses: actions/download-artifact@v4.1.8
         with:
           name: preview-${{ github.sha }}
           path: ./built-site
+
+      - name: Or make an empty folder... # Note: Git will ignore empty folders when commiting
+        if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'closed' }}
+        run: mkdir -p built-site
 
       - name: Checkout Site Builds
         uses: actions/checkout@v4
@@ -132,8 +138,6 @@ jobs:
         run: |
           git checkout --orphan new-site-builds site-builds
 
-          # move the new build in!
-
           # clean the directory - delete everything except for pr-previews and .git, a bit hacky really...
           mkdir -p ./pr-previews
           mkdir -p ./branch-previews
@@ -145,6 +149,7 @@ jobs:
           mv ../pr-previews ./pr-previews
           mv ../branch-previews ./branch-previews
 
+          # move the new build in!
           if [ "${event}" == "push" ]; then
             echo "Branch! ${ref}"
             mkdir -p "./branch-previews/${ref}" # also creates parent directories

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,57 +1,76 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Deploy current 'deployed'/PR previews
 
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["deployed"]
+    branches: ["deployed", "main"]
+
+  pull_request_target: # use trusted workflow (as opposed to `pull_request`)
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# Allow only one concurrent deployment per PR, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: preview-${{ github.ref }}
+  # cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: static-site
-      url: ${{ steps.deployment.outputs.page_url }}
+  # Creates a build of the website and uploads it as an artifact
+  # May be running untrusted code, so it's been given very restricted permissions
+  # Hopefully it can't do anything too bad...
+  build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          submodules: 'true'
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
+        env:
+          GITHUB_TOKEN: ''
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: splashkitonline
+          submodules: 'true'
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+        env:
+          GITHUB_TOKEN: ''
+
       - name: npm install
-        working-directory: ./Browser_IDE
+        working-directory: ./splashkitonline/Browser_IDE
         run: |
           npm install
+        env:
+          GITHUB_TOKEN: ''
+
       - name: shuffle folders
-        working-directory: ./Browser_IDE
+        working-directory: ./splashkitonline/Browser_IDE
         run: |
           mv node_modules/codemirror codemirror-5.65.15
           mv node_modules/jszip/dist jszip
           mv node_modules/@babel/standalone babel
           mv node_modules/split.js/dist split.js
           mv node_modules/mime/dist mime
+          rm -rf external/js-lzma/data
           mv ../DemoProjects DemoProjects
-      - name: download binaries #(hacky, please improve!) See https://github.com/thoth-tech/SplashkitOnline/pull/85
-        working-directory: ./Browser_IDE
+        env:
+          GITHUB_TOKEN: ''
+
+      - name: download binaries
+        working-directory: ./splashkitonline/Browser_IDE #python3 ./setup.py
         run: |
           wget -O splashkit/splashkit_autocomplete.json https://raw.githubusercontent.com/WhyPenguins/SplashkitOnline/github-live/Browser_IDE/splashkit/splashkit_autocomplete.json
           wget -O runtimes/javascript/bin/SplashKitBackendWASM.js https://raw.githubusercontent.com/WhyPenguins/SplashkitOnline/github-live/Browser_IDE/runtimes/javascript/bin/SplashKitBackendWASM.js
@@ -63,13 +82,141 @@ jobs:
           wget -O compilers/cxx/bin/lld.wasm.lzma https://raw.githubusercontent.com/WhyPenguins/SplashkitOnline/github-live/Browser_IDE/compilers/cxx/bin/lld.wasm.lzma
           wget -O runtimes/cxx/bin/SplashKitBackendWASMCPP.js https://raw.githubusercontent.com/WhyPenguins/SplashkitOnline/github-live/Browser_IDE/runtimes/cxx/bin/SplashKitBackendWASMCPP.js
           wget -O runtimes/cxx/bin/SplashKitBackendWASMCPP.worker.js https://raw.githubusercontent.com/WhyPenguins/SplashkitOnline/github-live/Browser_IDE/runtimes/cxx/bin/SplashKitBackendWASMCPP.worker.js
+        env:
+          GITHUB_TOKEN: ''
+
+      - name: Upload the build as an artifact
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: preview-${{ github.sha }}
+          path: ./splashkitonline/Browser_IDE
+          retention-days: 1
+          compression-level: 8
+          overwrite: true
+
+  # This part takes that artifact, merges it in to `site-builds` in its respective folder,
+  # and deploys.
+  deploy:
+    needs: build
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+      pull-requests: write
+    environment:
+      name: static-site
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: preview-${{ github.sha }}
+          path: ./built-site
+
+      - name: Checkout Site Builds
+        uses: actions/checkout@v4
+        with:
+          path: site-builds
+          submodules: 'false'
+          ref: site-builds
+
+      - name: Upload Built Archive
+        working-directory: ./site-builds
+        env:
+          action: ${{ github.event.action }}
+          event: ${{ github.event_name }}
+          pr: ${{ github.event.number }}
+          ref: ${{ github.ref_name }}
+        run: |
+          git checkout --orphan new-site-builds site-builds
+
+          # move the new build in!
+
+          # clean the directory - delete everything except for pr-previews and .git, a bit hacky really...
+          mkdir -p ./pr-previews
+          mkdir -p ./branch-previews
+          mv ./pr-previews ../
+          mv ./branch-previews ../
+          mv ./.git ../
+          cd ../ && rm -rf site-builds && mkdir site-builds && cd site-builds
+          mv ../.git ./.git
+          mv ../pr-previews ./pr-previews
+          mv ../branch-previews ./branch-previews
+
+          if [ "${event}" == "push" ]; then
+            echo "Branch! ${ref}"
+            mkdir -p "./branch-previews/${ref}" # also creates parent directories
+            rm -rf "./branch-previews/${ref}"
+            mv ../built-site "./branch-previews/${ref}"
+          elif [ "${event}" == "pull_request_target" ]; then
+            echo "PR! ${pr}"
+            rm -rf "./pr-previews/${pr}"
+            if [ "${action}" != "closed" ]; then
+              mv ../built-site "./pr-previews/${pr}"
+            fi
+          fi
+
+          # commit!
+          git config --global user.email "buildbot@bot.bot"
+          git config --global user.name "build-bot-bob"
+          git add --all --force
+          git commit -m "Update builds"
+          git branch -M new-site-builds site-builds
+          # TODO: This is race condition, if there are two simultaneous PRs only one will survive...
+          git push origin site-builds --force-with-lease
+
+          repoSiteURL=$(echo ${{ github.repository }} | sed 's/\//.github.io\//')
+          echo "repoSiteURL=$repoSiteURL" >> $GITHUB_ENV
+
+      - name: Structure Deployment # Put everything inside the `deployed` branch's folder
+        working-directory: ./site-builds
+        run: |
+          mkdir -p "./branch-previews/deployed" # just in case
+          mv "./branch-previews/deployed" ../deployed
+          mv ./* ../deployed/
+
+      - name: Checkout de-duplicate script # This way it's safe...
+        uses: actions/checkout@v4
+        with:
+          path: script
+          sparse-checkout: |
+            .github/workflows/generate_pr_map.py
+          sparse-checkout-cone-mode: false
+
+      - name: De-duplicate # I really wish GitHub supported hardlinks at least, this would have been much less painful...and save them space!
+        working-directory: ./deployed
+        run: python3 ../script/.github/workflows/generate_pr_map.py
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload IDE site
-          path: './Browser_IDE'
+          path: './deployed'
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      - name: Leave a link to the PR
+        if: ${{ success() && github.event_name == 'pull_request_target' && github.event.action != 'closed' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            | :whale2: **PR Preview!** |
+            | :-----: |
+            | Preview at https://${{ env.repoSiteURL }}/pr-previews/${{ github.event.number }} |
+            | for commit ${{ github.event.pull_request.head.sha }} |
+
+      - name: Or delete the link...
+        if: ${{ github.event_name == 'pull_request_target' && github.event.action == 'closed' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          delete: true
+          message: |
+            # PR Preview Removed

--- a/Browser_IDE/compilers/cxx/cxxCompilerClangWebWorker.js
+++ b/Browser_IDE/compilers/cxx/cxxCompilerClangWebWorker.js
@@ -6,6 +6,7 @@ importScripts('./../../external/js-lzma/src/wlzma.js');
 importScripts('./../../external/js-lzma/src/lzma.shim.js');
 
 self.wlzmaCustomPath = "./../../external/js-lzma/src/wlzma.wrk.js";
+self.downloadRootPath = "./../../";
 importScripts('./../../downloadHandler.js');
 
 // function to load the system libraries zip file

--- a/Browser_IDE/executionEnvironment.js
+++ b/Browser_IDE/executionEnvironment.js
@@ -303,6 +303,7 @@ class ExecutionEnvironment extends EventTarget{
                 runtimeFiles: language.runtimeFiles,
                 runtimeSizeAprox: language.runtimeSizeAprox,
                 compilerSizeAprox: language.compilerSizeAprox,
+                SKO: SKO,
             }, "*");
         }
         this.addEventListener("languageLoaderReady", f);

--- a/Browser_IDE/projectLoadUI.js
+++ b/Browser_IDE/projectLoadUI.js
@@ -66,7 +66,7 @@ async function ShowProjectLoader(title, getChoices){
                         displayEditorNotification("Switching language to " + item["language"] + "<br>Page will reload.", NotificationIcons.INFO);
 
                     // wait until the project has loaded, only then switch language if needed
-                    await loadProjectFromURL(item["file"]);
+                    await loadProjectFromURL(await rerouteURL(item["file"]));
 
                     if (activeLanguage.name != item["language"])
                         switchActiveLanguage(item["language"]);

--- a/Browser_IDE/runtimes/ExecutionEnvironmentInternalLoader.js
+++ b/Browser_IDE/runtimes/ExecutionEnvironmentInternalLoader.js
@@ -2,6 +2,9 @@
 
 let hasInitializedLanguage = false;
 
+
+let SKO = null;
+
 window.addEventListener('message', function(m){
     if (m.data.type == "InitializeLanguage"){
         if (hasInitializedLanguage){
@@ -9,6 +12,8 @@ window.addEventListener('message', function(m){
             return;
         }
         hasInitializedLanguage = true;
+
+        SKO = m.data.SKO;
 
         globalLoadingBarDownloadSet = new DownloadSet((progress) => {
             if (progress < 0) {

--- a/Browser_IDE/splashKitOnlineEnvParams.js
+++ b/Browser_IDE/splashKitOnlineEnvParams.js
@@ -24,5 +24,6 @@ let SKO = (function(){
         language: getEnvParam("language", "JavaScript", false), /*don't decode, so + remains + rather than a space*/
         useCompressedBinaries: getEnvParam("useCompressedBinaries", "on", true) == "on",
         useMinifiedInterface: getEnvParam("useMinifiedInterface") == "on",
+        isPRPreview: getEnvParam("isPRPreview", page_url.pathname.indexOf("/pr-previews/") >= 0 ? "on" : "off") == "on",
     };
 })();

--- a/Browser_IDE/splashKitOnlineEnvParams.js
+++ b/Browser_IDE/splashKitOnlineEnvParams.js
@@ -20,10 +20,13 @@ let SKO = (function(){
             return parsedRawParams[paramName] ?? _default;
     }
 
+    let isPreview =   (page_url.pathname.indexOf("/pr-previews/") >= 0)
+                   || (page_url.pathname.indexOf("/branch-previews/") >= 0);
+
     return {
         language: getEnvParam("language", "JavaScript", false), /*don't decode, so + remains + rather than a space*/
         useCompressedBinaries: getEnvParam("useCompressedBinaries", "on", true) == "on",
         useMinifiedInterface: getEnvParam("useMinifiedInterface") == "on",
-        isPRPreview: getEnvParam("isPRPreview", page_url.pathname.indexOf("/pr-previews/") >= 0 ? "on" : "off") == "on",
+        isPRPreview: getEnvParam("isPRPreview", isPreview ? "on" : "off") == "on",
     };
 })();


### PR DESCRIPTION
# Description

This PR extends the current workflow to support building multiple versions of the site and combining them into a single live site - this is used to support live previews of PRs, a preview of `main`, and the live current `deployed` version.

GitHub didn't make this easy 😅 Here's how it works:
1. We have a new branch, `site-builds` - it contains a folder for each build.
2. The workflow runs on changes to PRs/pushes. It first builds an artifact for the specific new site, by cloning and patching it like before. It runs with limited permissions since it's running arbitrary scripts in the PR - **we should have someone from cybersecurity check how secure this is...**
3. After this, a separate job with elevated permissions clones `site-builds`, merges in the new artifact, then squashes and pushes this. Finally it moves all the site builds into the `deployed` one, and then wraps those all up and deploys them as the new site.
4. If all goes well, it'll now leave a comment on the originating PR with a link to the deployment. If the PR was closed instead, it deletes the comment (and files). And of course does nothing if it was a direct push.

One ugly aspect of this was just keeping the file size down - each copy of SKO is about 150mb, so we'll reach the GitHub ~1GB limit really quickly. Unfortunately hardlinks aren't supported (for 'security' - symlinks I can understand, but I don't see how hardlinks could be abused ?). Instead, just before deploying the site, a script is ran that identifies identical files, and _deletes_ them. A file `PRPathMap.json` is then generated that maps the original files to their twin/quintuplet/etc. 

Now in SplashKit Online itself, that JSON file is read in, and used to reroute any urls passed through `rerouteURL(url)`, which are any large-ish files. I haven't been rigorous in making sure all URLs are passed through this, but currently all affected URLs are so I'm not too concerned.

And that's that! Hopefully this actually comes in handy haha.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've tested this a lot in my fork by creating various PRs, closing them, pushing to `deployed`, and so on. It _seems_ alright, but I wouldn't be surprised if there are remaining issues. I'm unsure how to test these workflows other than on a live repo, so I figure now that it's reasonably stable it'd just be best to merge it and see how it goes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
