### PR TITLE
Make the code editors open when a new project is created.

### DIFF
--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -501,6 +501,8 @@ async function newProject(initializer){
             await storedProject.access(async (project) => {
                 await project.renameProject("New Project");
             });
+
+            openCodeEditors();
         })()
     ])
 


### PR DESCRIPTION
Just a simple change, makes the code editors open when a new project is created.
(Also primarily a test for the new PR preview system)

_(Note to students: Usually we'd want more info than this! :P)_