### PR TITLE
Improve service worker handling

### DIFF
--- a/Browser_IDE/executionEnvironment.js
+++ b/Browser_IDE/executionEnvironment.js
@@ -303,6 +303,7 @@ class ExecutionEnvironment extends EventTarget{
                 runtimeFiles: language.runtimeFiles,
                 runtimeSizeAprox: language.runtimeSizeAprox,
                 compilerSizeAprox: language.compilerSizeAprox,
+                needsServiceWorker: language.needsServiceWorker,
                 SKO: SKO,
             }, "*");
         }

--- a/Browser_IDE/executionEnvironment_Page.js
+++ b/Browser_IDE/executionEnvironment_Page.js
@@ -195,7 +195,3 @@ function showDownloadFailure() {
 
 showLoadingContainer();
 updateLoadingProgress(0);
-
-let globalLoadingBarDownloadSet = null;
-let runtimeLoadingProgress = null;
-let compilerLoadingProgress = null;

--- a/Browser_IDE/languageDefinitions.js
+++ b/Browser_IDE/languageDefinitions.js
@@ -43,6 +43,7 @@ let SplashKitOnlineLanguageDefinitions = [
             persistentFilesystem: true,
             compiled: false,
             needsSandbox: true,
+            needsServiceWorker: false,
         }]
     },
     {
@@ -68,7 +69,7 @@ let SplashKitOnlineLanguageDefinitions = [
                 "external/js-lzma/src/lzma.shim.js",
                 "compilers/cxx/cxxCompiler.js",
             ],
-            runtimeSizeAprox: 10,
+            runtimeSizeAprox: 0, // user's compiled code becomes the 'runtime'
             compilerSizeAprox: 150,
             compilerName: "cxxCompiler",
             supportHotReloading: false,
@@ -76,6 +77,7 @@ let SplashKitOnlineLanguageDefinitions = [
             persistentFilesystem: false,
             compiled: true,
             needsSandbox: false,
+            needsServiceWorker: true,
         }]
     }
 ];

--- a/Browser_IDE/runtimes/ExecutionEnvironmentInternalLoader.js
+++ b/Browser_IDE/runtimes/ExecutionEnvironmentInternalLoader.js
@@ -2,6 +2,11 @@
 
 let hasInitializedLanguage = false;
 
+let globalLoadingBarDownloadSet = null;
+let runtimeLoadingProgress = null;
+let compilerLoadingProgress = null;
+let serviceWorkerLoadingProgress = null;
+let serviceWorkerLoaded = null;
 
 let SKO = null;
 
@@ -31,6 +36,13 @@ window.addEventListener('message', function(m){
 
         runtimeLoadingProgress = globalLoadingBarDownloadSet.addManualReporter(m.data.runtimeSizeAprox);
         compilerLoadingProgress = globalLoadingBarDownloadSet.addManualReporter(m.data.compilerSizeAprox);
+        serviceWorkerLoadingProgress = globalLoadingBarDownloadSet.addManualReporter(m.data.compilerSizeAprox*0.1);
+
+        if (m.data.needsServiceWorker){
+            serviceWorkerLoaded = registerServiceWorker(serviceWorkerLoadingProgress);
+        } else {
+            serviceWorkerLoadingProgress(1);
+        }
 
         console.log("Initializing with " + m.data.languageName);
         for (let script of m.data.runtimeFiles){
@@ -45,5 +57,107 @@ window.addEventListener('message', function(m){
         compilerLoadingProgress(m.data.progress);
     }
 }, false);
+
+
+
+// Service worker, which is used to provide a location we can send events to,
+// and that our user's program can recieve them from. Using a SharedArrayBuffer would of course
+// be better, but has less support (and also can't be served easily when hosting on GitHub)
+
+// heavily inspired by the work here: https://blog.persistent.info/2021/08/worker-loop.html
+
+let currentServiceWorker = null;
+let serviceWorkerChannel = null;
+
+function serviceWorkerSanityCheck() {
+    if (!currentServiceWorker)
+        return false;
+    if (currentServiceWorker.state == "redundant") {
+        executionEnvironment.Reload();
+    }
+    return true;
+}
+
+function sendWorkerCommand(command, args) {
+    if (!serviceWorkerSanityCheck())
+        return;
+
+    currentServiceWorker.postMessage({type: "programEvent", command, args});
+}
+
+// seperate function to keep performance up (sendWorkerCommand is called a _lot_)
+async function sendAwaitableWorkerCommand(command, args) {
+    if (!serviceWorkerSanityCheck())
+        return;
+
+    await serviceWorkerChannel.postMessage("programEvent", {command, args});
+}
+
+function clearWorkerCommands(command) {
+    if (!serviceWorkerSanityCheck())
+        return;
+
+    currentServiceWorker.postMessage({type: "clearEvents"});
+}
+async function registerServiceWorker(serviceWorkerLoadingProgress){
+    // first try tidying up any erroneous service workers
+    try {
+        navigator.serviceWorker.getRegistrations().then(registrations => {
+            for (const registration of registrations) {
+                if (registration.scope.includes("executionEnvironment.html"))
+                    registration.unregister();
+            }
+        });
+    }
+    catch(err) {
+        executionEnvironment.reportCriticalInitializationFail(
+            "Error when modifying service workers. <br/>"+
+            err.toString()
+        );
+    }
+
+    try {
+        let path = (new URL(window.location.href)).pathname;
+        let scope = path.slice(0,path.lastIndexOf("/")+1);
+
+        let worker = await navigator.serviceWorker.register("SKOservice-worker.js", { scope: scope });
+
+        worker.addEventListener("statechange", (event) => {
+            if (this.state == "activated" || this.state == "redundant") {
+                // trigger reload so service worker starts intercepting properly
+                executionEnvironment.Reload();
+                return true;
+            }
+        });
+
+        // Wait up to three second for it to become active - sometimes statechange just doesn't trigger...
+        // Seems to always work after the first delay - timing issue or perhaps just needs an async step?
+        for(let i = 0; i < 30; i ++) {
+            if (!worker.active) {
+                console.log("Wait " + i); // Leaving this in as it might be a useful thing to check when providing support
+                await new Promise((resolve,reject) => {setTimeout(function(){resolve();}, 100);});
+            }
+        }
+
+        if (worker.active) {
+            currentServiceWorker = worker.active;
+            serviceWorkerChannel = new PromiseChannel(navigator.serviceWorker, currentServiceWorker);
+
+            serviceWorkerLoadingProgress(1);
+            return true;
+        }
+
+        return false;
+    }
+    catch(err){
+        executionEnvironment.reportCriticalInitializationFail(
+            "Failed to initialize critical component: Service Worker. <br/>"+
+            "You can still compile and run programs, but you will be unable to interact with them with your mouse or keyboard.<br/>"+
+            err.toString()
+        );
+        return false;
+    }
+}
+
 
 parent.postMessage({type:"languageLoaderReady"}, "*");


### PR DESCRIPTION


# Description

This provides some small improvements on how service workers are handled:
 - decouples them from cxxRuntime
 - adds a wait for the worker to become active (it seems we can't rely on `statechange`)
   - **this fixes the 'C++ backend doesn't load first time' bug**
 - some other minor refactoring

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've deleted the service worker and used the C++ runtime multiple times without issues or needing to reload to get it working.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
