### PR TITLE
Update splashkit core module

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Finally this binary is executed securely in an asynchronous WebWorker. The WebWo
 ## "Backend" Development
 
 ### SplashKit Wasm Library Manual Compilation (JavaScript backend)
-First you'll need to install Emscripten, which will be used to compile SplashKit to Wasm so it can be used in the browser. The easiest way to do this is via the `emsdk`. Installation instructions are here - [Getting Started](https://emscripten.org/docs/getting_started/downloads.html)
+First, install Emscripten version 3.1.48, which is required to successfully build the SplashKit core and compile it to Wasm for browser use. The easiest way to do this is via the `emsdk`. Installation instructions are here - [Getting Started](https://emscripten.org/docs/getting_started/downloads.html)
 
 Once you've got Emscripten installed and activated, you can compile the SplashKit Wasm library! We've included SplashKit's source code as a submodule, along with the scripts to compile it as a Wasm library, directly in this repo.
 
@@ -88,6 +88,8 @@ emcmake cmake -G "Unix Makefiles" .
 emmake make
 ```
 If all goes well, you should find the three files built and copied to inside `Browser_IDE/runtimes/javascript/bin/` and `Browser_IDE/splashkit/` - if so, you're done!
+
+**Note:** Placing the project in a path with spaces can lead to errors during the build process.
 
 ### SplashKit Compiler Library Manual Compilation (C++ backend)
 It is also possible to use C++ within SplashKit Online! This is still experimental, and as such is missing some features and can be a bit unstable. However, the majority of graphics, audio, and input functionality works, and you can use it to compile and test regular C++ programs too!

--- a/SplashKitWasm/cmake/CMakeLists.txt
+++ b/SplashKitWasm/cmake/CMakeLists.txt
@@ -169,6 +169,7 @@ file(GLOB SOURCE_FILES
     "${SK_EXT}/sqlite/sqlite3.c"
     "${SK_EXT}/hash-library/*.cpp"
     "${SK_EXT}/easyloggingpp/*.cc"
+    "${SK_EXT}/microui/src/*.c"
 )
 
 if (EMSCRIPTEN)
@@ -204,6 +205,7 @@ include_directories("${SK_EXT}/hash-library")
 include_directories("${SK_EXT}/json")
 include_directories("${SK_EXT}/sqlite")
 include_directories("${SK_EXT}/catch")
+include_directories("${SK_EXT}/microui/src")
 include_directories("${SK_WASMEXT}/src/lib")
 
 # MAC OS AND WINDOWS DIRECTORY INCLUDES
@@ -345,7 +347,7 @@ set_target_properties(SplashKitBackendCXX
 if (EMSCRIPTEN)
     if (ENABLE_JS_BACKEND)
         add_executable(SplashKitBackendWASM "${SK_WASMEXT}/generated/SplashKitWasmGlue.cpp")
-        set_target_properties(SplashKitBackendWASM PROPERTIES LINK_FLAGS "-sALLOW_TABLE_GROWTH -s MAXIMUM_MEMORY=1gb -sALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=addFunction -s EXPORTED_FUNCTIONS=\"['_malloc','stackAlloc','stackSave','stackRestore','_free']\" -s EXPORT_ALL=1 -sFS_DEBUG --post-js ${SK_WASMEXT}/generated/SplashKitWasmGlue.js")
+        set_target_properties(SplashKitBackendWASM PROPERTIES LINK_FLAGS "-sALLOW_TABLE_GROWTH -s MAXIMUM_MEMORY=1gb -sALLOW_MEMORY_GROWTH -s EXPORTED_RUNTIME_METHODS=addFunction -s EXPORTED_FUNCTIONS=\"['_malloc','stackAlloc','stackSave','stackRestore','_free']\" -s EXPORT_ALL=1 -sFS_DEBUG --post-js \"${SK_WASMEXT}\"/generated/SplashKitWasmGlue.js")
         target_link_libraries(SplashKitBackendWASM SplashKitBackend) #NOTE: deliberately using SplashKitBackend rather than SplashKitBackendCXX - we don't care about the final linked output, we just want Emscripten to give us its JS runtime
         set_target_properties(SplashKitBackendWASM
             PROPERTIES

--- a/SplashKitWasm/tools/js_binding_gen/javascript_bindings_preamble.py
+++ b/SplashKitWasm/tools/js_binding_gen/javascript_bindings_preamble.py
@@ -49,6 +49,7 @@ CPPPreamble = """
 #include "web_client.h"
 #include "web_server.h"
 #include "window_manager.h"
+#include "interface.h"
 
 #include <cstring>
 #include <emscripten.h>


### PR DESCRIPTION
# Description

In this PR, I pulled the latest changes for the `splashkit-core` submodule using the Git command `git submodule update --init --remote --recursive`. Then, I followed the instructions in the "Backend Development" section of the README.

### Changes:
- A new `interface.h` file was added in the latest version of `splashkit-core`, requiring its inclusion in the compilation process. This was listed into the preamble file `SplashKitWasm/tools/js_binding_gen/javascript_bindings_preamble.py`, which is used for generating the JavaScript/C++ glue.
- The library **microui**, used in the `splashkit-core` module to handle UI, was included in the `CMakeLists.txt` file.

### Takeaways:
- Compilation works with EmSDK version **3.1.48**.
- To avoid errors, ensure the repository is placed in a path without spaces.
- After completing the build process, commit your changes and the autogenerated file `SplashKitWasm/external/splashkit-core`.
