### PR TITLE
Improve run/compile program notifications in Browser_IDE/editorMain.js

### DIFF
--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -749,19 +749,14 @@ function audioFunctionNotification(source) {
 async function runProgram(){
     try {
         clearErrorLines();
-		
-		// the notification object returned by displayEditorNotification
-		let currentNotification = displayEditorNotification(
-			activeLanguageSetup.compiled ? "Compiling project..." : "Building project...",
-			NotificationIcons.CONSTRUCTION,-1
-		);
-		
+       // the notification object returned by displayEditorNotification
+        const notificationMessage = activeLanguageSetup.compiled ? "Compiling project..." : "Building project...";
+        let currentNotification = displayEditorNotification(notificationMessage,NotificationIcons.CONSTRUCTION,-1);   
         // give the notification a chance to show
         await asyncSleep();
-
         let currentCompiler = await getCurrentCompiler();
 
-		if (currentCompiler == null) {
+        if (currentCompiler == null) {
             currentNotification.deleteNotification(); // delete the current notification if no compiler is found
             return;
         }
@@ -777,32 +772,26 @@ async function runProgram(){
         let compilableFiles = await findAllCompilableFiles();
         let sourceFiles = await findAllSourceFiles();
         if (compilableFiles.length == 0) {
-        	currentNotification.deleteNotification(); 
-            displayEditorNotification("Project has no source files! In a "+activeLanguage.name+" project, valid source files end with:</br><ul>"+
-                activeLanguage.compilableExtensions.map((s)=>"<li>."+s+"</li>").join("")+"</ul>",
-                NotificationIcons.ERROR,-1
-            );
+            currentNotification.deleteNotification(); 
+            const notificationMessage = "Project has no source files! In a " + activeLanguage.name + " project, valid source files end with:</br><ul>" + 
+            activeLanguage.compilableExtensions.map((s) => "<li>." + s + "</li>").join("") + "</ul>";
+            displayEditorNotification(notificationMessage,NotificationIcons.ERROR,-1);
             return;
         }
 
         let compiled = await currentCompiler.compileAll(await Promise.all(compilableFiles.map(mapBit)), await Promise.all(sourceFiles.map(mapBit)), reportCompilationError);
 
-		currentNotification.deleteNotification();
+        currentNotification.deleteNotification();
 
         if (compiled.output != null) {
             executionEnviroment.runProgram(compiled.output);
-        } else {
-            displayEditorNotification(
-			"Project has errors! Please see terminal for details.",
-			NotificationIcons.ERROR,-1
-			);
+        } 
+        else {
+            displayEditorNotification("Project has errors! Please see terminal for details.",NotificationIcons.ERROR,-1);
         }
     }
     catch (err) {
-        displayEditorNotification(
-		"Failed to run program!<br/>"+err.toString(),
-		NotificationIcons.ERROR,-1
-		);
+        displayEditorNotification("Failed to run program!<br/>"+err.toString(),NotificationIcons.ERROR,-1);
     }
 }
 


### PR DESCRIPTION
# Description

This change addresses the issue where notifications about compiling and running the program stack and quickly disappear when the user presses "Build and Run". This behavior is particularly problematic when the compilation takes a long time, as the vanishing notifications give the impression that the IDE is not doing anything.

To fix this, I’ve updated the notification system so that each notification will remain on screen for as long as needed, until the compilation moves to the next step. This ensures users have clear visibility of the compilation process, improving overall user experience.

Fixes # (issue) 
This change fixes the issue where notifications about compiling and running the program stack and quickly disappear, particularly when the compilation takes a long time.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

The change has been tested by triggering the "Build and Run" process with a compilation task of varying durations to ensure notifications stay visible until the next step. It has been verified that the notifications now remain on screen as expected, improving user interaction during long compile times.

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
