### PR TITLE
Add Action Queues concept and modify IDE and project loading to use them

### DIFF
--- a/Browser_IDE/AppStorage.js
+++ b/Browser_IDE/AppStorage.js
@@ -103,7 +103,7 @@ class __AppStorageRW{
             }
 
             transaction.onerror = function(){
-                console.log("error");
+                console.log("error", func);
                 transaction.abort(); 
                 reject(transaction.error);
             };
@@ -127,7 +127,7 @@ class __AppStorageRW{
             }
 
             result.onerror = function(){
-                console.log("error");
+                console.log("error", func);
                 transaction.abort(); 
                 reject(result.error);
             };

--- a/Browser_IDE/IDBStoredProject.js
+++ b/Browser_IDE/IDBStoredProject.js
@@ -31,6 +31,7 @@ class IDBStoredProject extends EventTarget{
                 return await s.getProject(_projectID);
             });
         }
+
         if(!_project){ // project not listed
             this.projectID = await this.appStorage.access(async (s) => {
                 return await s.createProject("untitled", _projectID);
@@ -396,7 +397,7 @@ class __IDBStoredProjectRW{
                 return;
             }
 
-            transaction.onerror = function(){console.log("error");transaction.abort(); reject(transaction.error);};
+            transaction.onerror = function(){console.log("error", func);transaction.abort(); reject(transaction.error);};
             transaction.oncomplete = function(){resolve(result);};
         });
     }
@@ -412,7 +413,7 @@ class __IDBStoredProjectRW{
                 return;
             }
 
-            result.onerror = function(){console.log("error");transaction.abort(); reject(result.error);};
+            result.onerror = function(){console.log("error", func);transaction.abort(); reject(result.error);};
             result.onsuccess = function(){resolve(result.result);};
         });
     }

--- a/Browser_IDE/IDEStartupMain.js
+++ b/Browser_IDE/IDEStartupMain.js
@@ -76,10 +76,13 @@ ActionQueue.OnClear([ExecutionEnvironmentLoadQueue, InitializeProjectQueue], asy
 });
 
 // Update execution state whenever these queues clear
-ActionQueue.OnClear([InitializeProjectQueue], updateCodeExecutionState);
-ActionQueue.OnClear([CompilerInitQueue], updateCodeExecutionState);
-ActionQueue.OnClear([ExecutionEnvironmentLoadQueue], updateCodeExecutionState);
-
+[
+    InitializeProjectQueue,
+    MirrorProjectQueue,
+    LoadProjectQueue,
+    CompilerInitQueue,
+    ExecutionEnvironmentLoadQueue,
+].forEach(queue => ActionQueue.OnClear([queue], updateCodeExecutionState));
 
 // TODO: refactor this so that it's clearer where each
 //       global variable is initialized/setup (should they be

--- a/Browser_IDE/IDEStartupMain.js
+++ b/Browser_IDE/IDEStartupMain.js
@@ -29,19 +29,23 @@ let InitializeProjectQueue = new ActionQueue("InitializeProjectQueue", {
 
 // These cancel if the project is re-initialized/loaded
 // Can have multipled scheduled - they don't cancel eachother out'
-let LoadProjectQueue = new ActionQueue("LoadProjectQueue", {
-    cancelRunning: false,
-    replaceQueued: false,
-    maxQueued: 100,
-    waitOn: [ExecutionEnvironmentLoadQueue, InitializeProjectQueue],
-    cancelOn: [InitializeProjectQueue],
-});
+/* Note: LoadProjectQueue actions use the UnifiedFS - so they write to both the
+         project FS and the transient FS in the ExecutableEnvironment.
+         We mirror inbetween 'Init'ing the project, and Loading data into it.
+*/
 let MirrorProjectQueue = new ActionQueue("MirrorProjectQueue", {
     cancelRunning: true,
     replaceQueued: true,
     maxQueued: 1,
-    waitOn: [LoadProjectQueue],
-    cancelOn: [InitializeProjectQueue, LoadProjectQueue],
+    waitOn: [InitializeProjectQueue],
+    cancelOn: [InitializeProjectQueue],
+});
+let LoadProjectQueue = new ActionQueue("LoadProjectQueue", {
+    cancelRunning: false,
+    replaceQueued: false,
+    maxQueued: 100,
+    waitOn: [ExecutionEnvironmentLoadQueue, InitializeProjectQueue, MirrorProjectQueue],
+    cancelOn: [InitializeProjectQueue],
 });
 
 // This only executes if everything has loaded, and cancels if another project is loaded

--- a/Browser_IDE/IDEStartupMain.js
+++ b/Browser_IDE/IDEStartupMain.js
@@ -45,7 +45,7 @@ let LoadProjectQueue = new ActionQueue("LoadProjectQueue", {
     replaceQueued: false,
     maxQueued: 100,
     waitOn: [ExecutionEnvironmentLoadQueue, InitializeProjectQueue, MirrorProjectQueue],
-    cancelOn: [InitializeProjectQueue],
+    cancelOn: [InitializeProjectQueue, ExecutionEnvironmentLoadQueue],
 });
 
 // This only executes if everything has loaded, and cancels if another project is loaded

--- a/Browser_IDE/actionQueue.js
+++ b/Browser_IDE/actionQueue.js
@@ -13,27 +13,59 @@ class ActionQueue extends EventTarget {
         this.queue = [];
         this.current = null;
 
+        this.isConsuming = false;
+
+        if (!this.concurrency.synchronousWith) this.concurrency.synchronousWith = [];
+        if (!this.concurrency.waitOn) this.concurrency.waitOn = [];
+        if (!this.concurrency.cancelOn) this.concurrency.cancelOn = [];
+
         let self = this;
 
         ActionQueue.OnClear(this.concurrency.waitOn, function() {
             // Start the consume loop if required
-            if (self.current == null)
                 self.Consume();
         });
 
-        if (this.concurrency.cancelOn)
-            for (let i = 0; i < this.concurrency.cancelOn.length; i ++) {
-                this.concurrency.cancelOn[i].addEventListener("onAddedOne", function() {
-                    self.log("    Clearing all to " + self.concurrency.cancelOn[i].name + " queue having an item added");
-                    if (self.current != null)
-                        try{self.current.cancelled.cancel(new ActionCancelled());}catch(err){}
-                    self.queue = [];
+        for (let i = 0; i < this.concurrency.cancelOn.length; i ++) {
+            let targetQueue = this.concurrency.cancelOn[i];
+            // cancel and clear when target queue has an action added
+            targetQueue.addEventListener("onAddedOne", function() {
+                if (self.isClear())
+                    return;
+
+                self.log("    Clearing all due to " + self.concurrency.cancelOn[i].name + " queue having an item added");
+
+                self.cancelCurrent();
+                self.queue = [];
+            });
+
+            // we also want the target queue to _wait_ for this queue to finish up whatever it was doing
+            if (targetQueue.concurrency.synchronousWith.indexOf(this) < 0) {
+                targetQueue.concurrency.synchronousWith.push(this);
+                ActionQueue.OnConsumedOne([this], function() {
+                    // Start the consume loop if required
+                    targetQueue.Consume();
                 });
             }
+
+        }
     }
 
     isClear() {
         return this.queue.length == 0 && this.current == null;
+    }
+
+    isExecuting() {
+        return this.current != null;
+    }
+
+    async cancelCurrent() {
+        if (this.current != null)
+            try {
+                await this.current.cancel();
+                await this.current.promise;
+            }
+            catch(err) {}
     }
 
     log(text){
@@ -46,7 +78,7 @@ class ActionQueue extends EventTarget {
         // Cancel if this will exceed the max queue length _including_ the current executing one
         if (this.queue.length >= this.concurrency.maxQueued && this.concurrency.cancelRunning && this.current != null) {
             this.log("    Cancelling current");
-            try{this.current.cancelled.cancel(new ActionCancelled());}catch(err){}
+            this.cancelCurrent();
         }
 
         // Remove the first queued one if adding this will exceed the max queue length
@@ -62,15 +94,69 @@ class ActionQueue extends EventTarget {
         this.dispatchEvent(new Event("onAddedOne"));
 
         // Start the consume loop if required
-        if (this.current == null) {
+        if (!this.isConsuming) {
             this.log("    Begin the consume loop");
             this.Consume();
         }
     }
 
     async Consume() {
-        this.log("Consume");
-        if (this.current != null) {
+        // guard against running this multiple times simultaneously
+        if (this.isConsuming)
+            return;
+
+        this.isConsuming = true;
+        this.log("Consume loop began");
+
+        consumeLoop:
+        while(this.queue.length > 0) {
+            this.log("Consume");
+
+            // first wait for all waitOn queues to completely empty
+            for (let i = 0; i < this.concurrency.waitOn.length; i ++) {
+                if (!this.concurrency.waitOn[i].isClear()) {
+                    this.log("    Waiting on " + this.concurrency.waitOn[i].name + " queue to finish all tasks");
+                    break consumeLoop;
+                }
+            }
+
+            // also wait for all synchronousWith queues to finish their current task
+            for (let i = 0; i < this.concurrency.synchronousWith.length; i ++) {
+                if (this.concurrency.synchronousWith[i].isExecuting()) {
+                    this.log("    Waiting on " + this.concurrency.synchronousWith[i].name + " queue to finish current task");
+                    break consumeLoop;
+                }
+            }
+
+
+            // create the 'action'
+            this.log("    Starting action " + this.queue[0].name);
+            let action = {promise: null, cancelled: false, cancel: null};
+
+            // this function cancels the action
+            let cancelFunc = function() {
+                action.cancelled = true;
+            };
+
+            // this function checks if the action is cancelled, and throws if it is
+            // can be called at any point inside an action's function
+            let checkCancelled = function() {
+                if (action.cancelled)
+                    throw new ActionCancelled();
+            };
+
+            // fill in the action, and actually start the function
+            action.cancel = cancelFunc;
+            action.promise = this.queue[0].func(checkCancelled);
+            action.name = this.queue[0].name; // mainly for debugging
+            action.origFunc = this.queue[0].func; // mainly for debugging
+            this.current = action;
+
+            // remove the first element from the queue (since we've started it)
+            this.queue.splice(0, 1);
+
+
+            // wait for the action to finish, and catch any errors
             this.log("    Waiting for current task to finish");
             try {
                 await this.current.promise;
@@ -78,37 +164,17 @@ class ActionQueue extends EventTarget {
                 this.log("    Current task ended with error:");
                 this.log(err);
             }
+
             this.log("    Current task finished");
+
+            // tidy up and signal completion, then loop again and see if there
+            // are any other actions to run
+            this.current = null;
+            this.dispatchEvent(new Event("onConsumedOne"));
         }
 
-        for (let i = 0; i < this.concurrency.waitOn.length; i ++) {
-            if (!this.concurrency.waitOn[i].isClear()) {
-                this.log("    Waiting on " + this.concurrency.waitOn[i].name + " queue to finish");
-                return;
-            }
-        }
-
-        if (this.queue.length > 0) {
-            this.log("    Starting activity "+this.queue[0].name);
-            let action = {promise: null, cancelled: null};
-
-
-            let resolved = Promise.resolve();
-            let cancelFunc = null;
-            let cancellable = new Promise(function (resolve, reject) {cancelFunc = reject;});
-            let checkCancelled = function(){return Promise.race([cancellable, resolved]);};
-            checkCancelled.cancelledPromise = cancellable;
-            checkCancelled.cancel = cancelFunc;
-            action.cancelled = checkCancelled;
-            action.promise = this.queue[0].func(checkCancelled);
-            let self = this;
-            action.promise.then(function() {self.current = null; self.dispatchEvent(new Event("onConsumedOne"));} );
-            action.promise.catch(function(err){console.log("ERROR", self.name, err);});
-            this.current = action;
-            this.queue.splice(0, 1);
-            this.Consume();
-            return;
-        }
+        this.isConsuming = false;
+        this.log("Consume loop ended");
     }
 
     static OnClear(queues, func) {
@@ -119,6 +185,15 @@ class ActionQueue extends EventTarget {
                     if (!queues[i].isClear())
                         return;
                 }
+                func();
+            });
+        }
+    }
+
+    static OnConsumedOne(queues, func) {
+        for (let i = 0; i < queues.length; i ++) {
+            let self = this;
+            queues[i].addEventListener("onConsumedOne", function() {
                 func();
             });
         }

--- a/Browser_IDE/actionQueue.js
+++ b/Browser_IDE/actionQueue.js
@@ -1,0 +1,124 @@
+class ActionCancelled extends Error {
+  constructor(message = "", ...args) {
+    super(message, ...args);
+    this.message = "Cancelled the action!";
+  }
+}
+class ActionQueue extends EventTarget {
+
+    constructor(name, concurrency) {
+        super();
+        this.name = name;
+        this.concurrency = concurrency;
+        this.queue = [];
+        this.current = null;
+
+        let self = this;
+
+        ActionQueue.OnClear(this.concurrency.waitOn, function() {
+            // Start the consume loop if required
+            if (self.current == null)
+                self.Consume();
+        });
+
+        if (this.concurrency.cancelOn)
+            for (let i = 0; i < this.concurrency.cancelOn.length; i ++) {
+                this.concurrency.cancelOn[i].addEventListener("onAddedOne", function() {
+                    self.log("    Clearing all to " + self.concurrency.cancelOn[i].name + " queue having an item added");
+                    if (self.current != null)
+                        try{self.current.cancelled.cancel(new ActionCancelled());}catch(err){}
+                    self.queue = [];
+                });
+            }
+    }
+
+    log(text){
+        //console.log(this.name, text); // uncomment to help with debugging... TODO: Maybe this can be made tidier?
+    }
+
+    async Schedule(name, func) {
+        this.log("Scheduling " + name);
+        this.queue.push({name:name, func:func});
+        // Cancel if this will exceed the max queue length _including_ the current executing one
+        if (this.queue.length >= this.concurrency.maxQueued && this.concurrency.cancelRunning && this.current != null) {
+            this.log("    Cancelling current");
+            try{this.current.cancelled.cancel(new ActionCancelled());}catch(err){}
+        }
+
+        // Remove the first queued one if adding this will exceed the max queue length
+        if (this.queue.length > this.concurrency.maxQueued && this.concurrency.replaceQueued) {
+            this.log("    Remove first queued");
+            this.queue.splice(0, 1);
+        }
+
+        // Remove any items in the queue past the queue length
+        this.queue.splice(0, this.queue.length - this.concurrency.maxQueued);
+        this.log("    There are now " + this.queue.length + " items queued");
+
+        this.dispatchEvent(new Event("onAddedOne"));
+
+        // Start the consume loop if required
+        if (this.current == null) {
+            this.log("    Begin the consume loop");
+            this.Consume();
+        }
+    }
+
+    async Consume() {
+        this.log("Consume");
+        if (this.current != null) {
+            this.log("    Waiting for current task to finish");
+            try {
+                await this.current.promise;
+            } catch (err){
+                this.log("    Current task ended with error:");
+                this.log(err);
+            }
+            this.log("    Current task finished");
+        }
+
+        for (let i = 0; i < this.concurrency.waitOn.length; i ++) {
+            if (this.concurrency.waitOn[i].queue.length != 0 || this.concurrency.waitOn[i].current != null) {
+                this.log("    Waiting on " + this.concurrency.waitOn[i].name + " queue to finish");
+                return;
+            }
+        }
+
+        if (this.queue.length > 0) {
+            this.log("    Starting activity "+this.queue[0].name);
+            let action = {promise: null, cancelled: null};
+
+
+            let resolved = Promise.resolve();
+            let cancelFunc = null;
+            let cancellable = new Promise(function (resolve, reject) {cancelFunc = reject;});
+            let checkCancelled = function(){return Promise.race([cancellable, resolved]);};
+            checkCancelled.cancelledPromise = cancellable;
+            checkCancelled.cancel = cancelFunc;
+            action.cancelled = checkCancelled;
+            action.promise = this.queue[0].func(checkCancelled);
+            let self = this;
+            action.promise.then(function() {self.current = null; self.dispatchEvent(new Event("onConsumedOne"));} );
+            action.promise.catch(function(err){console.log("ERROR", self.name, err);});
+            this.current = action;
+            this.queue.splice(0, 1);
+            this.Consume();
+            return;
+        }
+    }
+
+    static OnClear(queues, func) {
+        for (let i = 0; i < queues.length; i ++) {
+            let self = this;
+            queues[i].addEventListener("onConsumedOne", function() {
+                for (let i = 0; i < queues.length; i ++) {
+                    if (queues[i].queue.length != 0 || queues[i].current != null)
+                        return;
+                }
+                func();
+            });
+        }
+    }
+
+};
+

--- a/Browser_IDE/actionQueue.js
+++ b/Browser_IDE/actionQueue.js
@@ -32,6 +32,10 @@ class ActionQueue extends EventTarget {
             }
     }
 
+    isClear() {
+        return this.queue.length == 0 && this.current == null;
+    }
+
     log(text){
         //console.log(this.name, text); // uncomment to help with debugging... TODO: Maybe this can be made tidier?
     }
@@ -78,7 +82,7 @@ class ActionQueue extends EventTarget {
         }
 
         for (let i = 0; i < this.concurrency.waitOn.length; i ++) {
-            if (this.concurrency.waitOn[i].queue.length != 0 || this.concurrency.waitOn[i].current != null) {
+            if (!this.concurrency.waitOn[i].isClear()) {
                 this.log("    Waiting on " + this.concurrency.waitOn[i].name + " queue to finish");
                 return;
             }
@@ -112,7 +116,7 @@ class ActionQueue extends EventTarget {
             let self = this;
             queues[i].addEventListener("onConsumedOne", function() {
                 for (let i = 0; i < queues.length; i ++) {
-                    if (queues[i].queue.length != 0 || queues[i].current != null)
+                    if (!queues[i].isClear())
                         return;
                 }
                 func();

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -1394,4 +1394,5 @@ function AddWindowListeners(){
                 break;
         }
     }, false);
+    parent.postMessage({type:"SplashKitOnlineListening"}, "*");
 }

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -582,7 +582,12 @@ function enableCodeExecution(){
 }
 // automatically enable/disable based on IDE state
 function updateCodeExecutionState(){
-    if (getCompiler(activeLanguageSetup.compilerName) && executionEnviroment.readyForExecution) {
+    if (InitializeProjectQueue.isClear() &&
+        MirrorProjectQueue.isClear() &&
+        LoadProjectQueue.isClear() &&
+        getCompiler(activeLanguageSetup.compilerName) &&
+        executionEnviroment.readyForExecution
+    ){
         executionEnviroment.updateCompilerLoadProgress(1);
         enableCodeExecution();
     }

--- a/Browser_IDE/editorMain.js
+++ b/Browser_IDE/editorMain.js
@@ -538,7 +538,7 @@ async function MirrorToExecutionEnvironment(){
             for(let node of dirs_files){
                 let abs_path = path+""+node.label;
                 if (node.children != null){
-                    promises.push(executionEnviroment.mkdir(abs_path));
+                    promises.push(FSEnsureDir(executionEnviroment, abs_path));
                     await mirror(node.children, abs_path+"/");
                 }
                 else{
@@ -1000,6 +1000,14 @@ some stuff that exists in StoredProject.
 */
 function FSsplitPath(path){
     return path.split("/").slice(1);
+}
+async function FSEnsureDir(FS, path) {
+    try {
+        await FS.mkdir(path);
+    } catch (err){
+        if (err.toString() != "ErrnoError: File exists" /*again, a hack to deal with our various error types. Something like err.errno != 20 (from Module['ERRNO_CODES']['EEXIST']) would be nicer*/)
+            throw err;
+    }
 }
 async function FSEnsurePath(FS, path) {
     let pathBits = FSsplitPath(path);

--- a/Browser_IDE/index.html
+++ b/Browser_IDE/index.html
@@ -62,7 +62,7 @@
 					</div>
 				</div>
 				<input type="file" id="fileuploader" onchange="uploadFileFromInput()" style="display:none;">
-				<input type="file" id="projectuploader" onchange="uploadProjectFromInput()" style="display:none;">
+				<input type="file" id="projectuploader" onchange="scheduleUploadProjectFromInput()" style="display:none;">
 				<div class = "sk-header-indent sk-contents sk-contents-focusable" tabindex="0">
 					<div id="fileView"></div>
 				</div>
@@ -143,5 +143,6 @@
 <script src="editorMain.js"></script>
 <script src="fileview.js"></script>
 <script src="projectLoadUI.js"></script>
+<script src="actionQueue.js"></script>
 <script src="IDEStartupMain.js"></script>
 </html>

--- a/Browser_IDE/projectLoadUI.js
+++ b/Browser_IDE/projectLoadUI.js
@@ -65,11 +65,10 @@ async function ShowProjectLoader(title, getChoices){
                     if (activeLanguage.name != item["language"])
                         displayEditorNotification("Switching language to " + item["language"] + "<br>Page will reload.", NotificationIcons.INFO);
 
-                    // wait until the project has loaded, only then switch language if needed
-                    await loadProjectFromURL(await rerouteURL(item["file"]));
+                    let reroutedURL = await rerouteURL(item["file"]);
 
-                    if (activeLanguage.name != item["language"])
-                        switchActiveLanguage(item["language"]);
+                    scheduleLoadProjectFromURL(reroutedURL);
+                    schedulePotentialLanguageSwitch(item["language"]);
                 });
             }
             gridContainer.appendChild(set);


### PR DESCRIPTION
# Description

SplashKit Online has issues with concurrency, and has a variety of work-arounds in random spots to try and hide them. Rapidly clicking New Project for instance would cause errors, so we have a `makingNewProject` variable that we use to ignore the button while making a new project. Other similar issues such as loading a project, but clicking New Project mid-way, etc, could all cause issues such as database corruption and a broken IDE. It's also impossible to cancel any operations, including long running ones like loading demo projects.

This commit introduces the concept of Action Queues, which as the name suggests gives us synchronous queues in-which to perform actions (such as loading projects, initializing parts of the IDE, etc). 
 - Action Queues simply run each action in their queue synchronously - one action must finish before the next begins.
 - Action Queues have queuing settings - it's possible to limit the maximum number of actions queued (typically to 1), to _cancel_ currently running actions if a new one is queued in the same queue, and to remove other queued ones so later ones take precedence.
 - These queues can also have dependencies between each other - a queue will simply _wait_ until the queues it depends on are empty. As an example, it doesn't make sense to Load a project until the project has finished being Initialized (database created, etc)
 - A queue can also _clear_ itself upon change to another queue. For instance, it doesn't make sense to Load a project if _after_ the load commences, the project is re-initialized.
 - As mentioned, actions in the queue can be _cancelled_. There's no way to do this explicitly in the interface, but as an example, starting a load of a demo project will be canceled by clicking New Project or loading a different project.

The commit adds a set of default action queues for the current set of actions that can be performed, and modified startup and loading code to use these queues.

This also allows the IDE to begin listening to events from the outside world immediately, as it can just queue up the actions those messages request.

**Note:** This code isn't very good :yum:  I'd really appreciate if someone can review it in detail, or even better offer to finish tidying it up (in which case I'll merge it into a branch you can work off, and that branch can be merged into main once it's tidied).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Mostly just spam clicked around. Tested loading projects, new projects, loading demos, switching languages, etc. ~~Honestly though there are still some minor errors that appear when really abusing the IDE - no worse than before though.~~ Fixed! No errors show up at all now 😄 

~~It really needs more testing, and there are a few spots in the code that should be tidied/refactored as well.~~ Also improved, hopefully code quality is _alright_ now anyway...

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
