### PR TITLE
Add projectID

### DIFF
--- a/Browser_IDE/IDEStartupMain.js
+++ b/Browser_IDE/IDEStartupMain.js
@@ -105,7 +105,8 @@ async function StartIDE() {
         let projectID = SKO.projectID;
         if (projectID) {
             storedProject = new IDBStoredProject(appStorage, projectID);  // Use project ID if available
-        } else {
+        } 
+        else {
             storedProject = new IDBStoredProject(appStorage, activeLanguageSetup.getDefaultProject());  // Default project
         }
 

--- a/Browser_IDE/IDEStartupMain.js
+++ b/Browser_IDE/IDEStartupMain.js
@@ -98,10 +98,17 @@ async function StartIDE() {
         setupIDEButtonEvents(); // uses current language
 
         // Create execution environment and project storage objects
-        // These constructors don't _do_ anything important.
         executionEnviroment = new ExecutionEnvironment(document.getElementById("ExecutionEnvironment"), activeLanguageSetup);
         appStorage = new AppStorage();
-        storedProject = new IDBStoredProject(appStorage, activeLanguageSetup.getDefaultProject());
+        
+        // Check if projectID exists in URL, if so, load that project
+        let projectID = SKO.projectID;
+        if (projectID) {
+            storedProject = new IDBStoredProject(appStorage, projectID);  // Use project ID if available
+        } else {
+            storedProject = new IDBStoredProject(appStorage, activeLanguageSetup.getDefaultProject());  // Default project
+        }
+
         unifiedFS = new UnifiedFS(storedProject, executionEnviroment);
 
         // Setup callbacks/listeners

--- a/Browser_IDE/splashKitOnlineEnvParams.js
+++ b/Browser_IDE/splashKitOnlineEnvParams.js
@@ -28,5 +28,7 @@ let SKO = (function(){
         useCompressedBinaries: getEnvParam("useCompressedBinaries", "on", true) == "on",
         useMinifiedInterface: getEnvParam("useMinifiedInterface") == "on",
         isPRPreview: getEnvParam("isPRPreview", isPreview ? "on" : "off") == "on",
+        // add projectID
+        projectID: getEnvParam("projectID", null, true) 
     };
 })();

--- a/Browser_IDE/splashKitOnlineEnvParams.js
+++ b/Browser_IDE/splashKitOnlineEnvParams.js
@@ -28,7 +28,6 @@ let SKO = (function(){
         useCompressedBinaries: getEnvParam("useCompressedBinaries", "on", true) == "on",
         useMinifiedInterface: getEnvParam("useMinifiedInterface") == "on",
         isPRPreview: getEnvParam("isPRPreview", isPreview ? "on" : "off") == "on",
-        // add projectID
-        projectID: getEnvParam("projectID", null, true) 
+        projectID: getEnvParam("projectID", null, true) // add projectID
     };
 })();


### PR DESCRIPTION
# Description

_This change introduces the ability to load or create a specific project via a URL parameter. A new environment parameter is added, allowing the user to specify the Project ID directly in the URL. For example, by appending ?project_id=17256468, the system will load the project with that ID. This feature enhances the user experience by enabling direct access to a specific project without manual selection_

Fixes # (issue)

## Type of change

_Please delete options that are not relevant._

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

_The feature was tested by adding a project ID in the URL. When a project ID was provided, the system loaded the specific project associated with that ID. If no project ID was given, the system loaded the last project that was opened. Switching between projects by changing the project ID confirmed that the correct project was loaded_

## Testing Checklist

- [x] Tested in latest Chrome
- [ ] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
