### PR TITLE
Add guide for adding custom themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ out/
 splashkit/splashkit_autocomplete.json
 generated/
 __pycache__/
-_framework/
+_framework/.DS_Store

--- a/Documentation/add-theme-guide.md
+++ b/Documentation/add-theme-guide.md
@@ -1,0 +1,50 @@
+# Adding a Custom Theme to SplashKit Online
+
+The guide provides instructions for adding new themes to the SplashKit Online editor through theme.js and colors.css modifications and user interface updates for theme selection functionality.
+
+## Files Involved
+- `javascript/UI/themes.js`
+- `css/colours.css`
+- `index.html`
+
+## Add Theme Colours to *theme.js*
+
+Add your preferred color values to the themes object in javascript/UI/themes.js. 
+
+```js
+"myCustomTheme": {
+  "editorBackgroundColour": "#2e3440",
+  "editorKeyword": "#81a1c1",
+  "editorComment": "#616e88",
+  "editorLineNumber": "#d8dee9",
+  "editorGutterBackground": "#3b4252",
+  "editorString": "#a3be8c"
+}
+```
+
+
+## Theme Selector in *index.html* is updated 
+
+Make sure that this is updated, as this is resposible for enabling users to select the theme. 
+
+```html
+<li style="margin-left:1rem">
+<div>Theme:&nbsp;</div>
+<select id="themeSelection"></select>
+</li>
+```
+
+## CSS Variables in *colours.css*
+
+The Themes system enables runtime modification of CSS variables through its functionality. The available variables exist within the css/colours.css file which you can access for viewing.
+
+```css
+--editorKeyword
+--editorComment
+--editorLineNumber
+--editorBackgroundColour
+--editorString
+--editorGutterBackground
+--shadowColour
+```
+

--- a/Documentation/add-theme-guide.md
+++ b/Documentation/add-theme-guide.md
@@ -39,12 +39,55 @@ Make sure that this is updated, as this is resposible for enabling users to sele
 The Themes system enables runtime modification of CSS variables through its functionality. The available variables exist within the css/colours.css file which you can access for viewing.
 
 ```css
+/* Code editor colours */
 --editorKeyword
 --editorComment
---editorLineNumber
---editorBackgroundColour
---editorString
 --editorGutterBackground
+--editorLineNumber
+--editorFunctionsAndObject
+--editorProperty
+--editorNumber
+--editorSelected
+--editorString
+--editorMeta
+--editorVariable2
+--editorType
+--editorBackgroundColour
+
+/* UI colours */
+--gutterColour
+--disabled
+--errorColour
+--warning
+--activeTabColour
+--nodeConflict
+--languageSelectBackground
+--errorLineBackground
+--transientColour
+
+/* Gutter colours */
 --shadowColour
+--nodeHover
+--fileColour
+--iconHover
+
+/* Terminal colours */
+--terminalBackground
+
+/* Text */
+--primary
+
+/* Demo colours */
+--language
+--tagBackground
+--demoTitleBackground
+--demoThumbnailBackground
+
+/* Loading bar */
+--loadingBackground
+
+/* Fonts */
+--font
+--editorFont
 ```
 


### PR DESCRIPTION
# Description

A new markdown document named **add-theme-guide.md** exists within the Documentation/ folder. The guide provides instructions for adding custom themes to SplashKit Online through **theme.js** modifications and **color.css** updates and **index.html** changes.


## Type of change

- [ ✓] Documentation (update or new)

## How Has This Been Tested?

The instructions were verified to match the current project structure and implementation. The .md file was previewed in Visual Studio Code to verify the correct formatting.

## Checklist

- [✓ ] My code follows the style guidelines of this project
- [✓ ] I have performed a self-review of my own code
- [✓ ] I have commented my code in hard-to-understand areas
- [✓ ] I have made corresponding changes to the documentation
- [✓ ] My changes generate no new warnings
- [✓ ] I have requested a review from ... on the Pull Request

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/b50c9068-6bce-4af2-be84-e2e52616312c" />

