### PR TITLE
Fix: prevent XSS in createModal by building modal via DOM APIs (avoid…

### DIFF
--- a/javascript/UI/modal.js
+++ b/javascript/UI/modal.js
@@ -1,46 +1,100 @@
 "use strict";
 
-// Thin wrapper around Bootstrap, in case we stop using it later
-function createModal(name, title, content, primaryButton, secondaryButton = null){
+// helper: create element, set attrs/styles, append children
+function elem(tag, attrs = {}, childElems = []){
+    let elem = document.createElement(tag);
 
-    let modal = document.createElement("div");
+    for (const [attrName, attrVal] of Object.entries(attrs)){
+        if (attrName == 'style'){
+            for (const [styleName, styleVal] of Object.entries(attrVal)){
+                elem.style[styleName] = styleVal;
+            }
+        } else {
+            elem.setAttribute(attrName, attrVal);
+        }
+    }
 
-    // Create via string template...
-    let modalString = [
-    '<div id="'+name+'" tabindex="-1" class="modal fade" aria-hidden="true" aria-labelledby="exampleModalLabel">',
-    '  <div class="modal-dialog">',
-    '    <div class="sk-contents">',
-    '      <div class="sk-header sk-header-indent">',
-    '        <h2>'+title+'</h2>',
-    '        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>',
-    '      </div>',
-    '      <div class="sk-contents modal-body">',
-    '        '+content+'',
-    '      </div>',
-    '      <div class="sk-header sk-modal-footer">',
-    '      </div>',
-    '    </div>',
-    '  </div>',
-    '</div>'].join("\n");
+    // append strings (-> TextNode) or Node objects
+    elem.append(...childElems);
 
-    modal.innerHTML = modalString;
+    return elem;
+}
 
-    if (secondaryButton != null){
-        var sButton = document.createElement("button");
-        sButton.classList.add("btn","btn-secondary");
-        sButton.innerText = secondaryButton.label;
+// parse HTML string into a document body (use with care)
+function elemFromText(text) {
+    return new DOMParser().parseFromString(text, "text/html").body;
+}
+
+// fade out and remove element
+function removeFadeOut(el, speed) {
+    var seconds = speed/1000;
+    el.style.transition = "opacity " + seconds + "s ease";
+    el.style.opacity = 0;
+    setTimeout(function() {
+        if (el.parentNode) el.parentNode.removeChild(el);
+    }, speed);
+}
+
+// createModal: builds a Bootstrap modal safely (no innerHTML)
+function createModal(name, title, content, primaryButton, secondaryButton = null) {
+    const modal = elem("div", {
+        id: name,
+        class: "modal fade",
+        tabindex: "-1",
+        "aria-hidden": "true",
+        "aria-labelledby": "exampleModalLabel"
+    });
+
+    const dialog = elem("div", { class: "modal-dialog" });
+    modal.append(dialog);
+
+    const contents = elem("div", { class: "sk-contents" });
+    dialog.append(contents);
+
+    // header (title as text)
+    const header = elem("div", { class: "sk-header sk-header-indent" }, [
+        elem("h2", {}, [document.createTextNode(title)]),
+        elem("button", {
+            type: "button",
+            class: "btn-close btn-close-white",
+            "data-bs-dismiss": "modal",
+            "aria-label": "Close"
+        })
+    ]);
+    contents.append(header);
+
+    // body: string -> TextNode; Node -> append
+    const bodyNode = elem("div", { class: "sk-contents modal-body" });
+    if (typeof content === "string") {
+        bodyNode.appendChild(document.createTextNode(content));
+    } else if (content instanceof Node) {
+        bodyNode.appendChild(content);
+    } else {
+        bodyNode.appendChild(document.createTextNode(String(content)));
+    }
+    contents.append(bodyNode);
+
+    // footer and buttons
+    const footer = elem("div", { class: "sk-header sk-modal-footer" });
+    contents.append(footer);
+
+    if (secondaryButton) {
+        const sButton = elem("button", { class: "btn btn-secondary" }, [
+            document.createTextNode(secondaryButton.label)
+        ]);
         sButton.onclick = secondaryButton.callback;
-        modal.getElementsByClassName("sk-modal-footer")[0].appendChild(sButton);
+        footer.appendChild(sButton);
     }
-    if (primaryButton != null){
-        var pButton = document.createElement("button");
-        pButton.classList.add("btn","btn-success");
-        pButton.innerText = primaryButton.label;
+
+    if (primaryButton) {
+        const pButton = elem("button", { class: "btn btn-success" }, [
+            document.createTextNode(primaryButton.label)
+        ]);
         pButton.onclick = primaryButton.callback;
-        modal.getElementsByClassName("sk-modal-footer")[0].appendChild(pButton);
+        footer.appendChild(pButton);
     }
 
+    // attach and return Bootstrap modal instance
     document.body.appendChild(modal);
-
-    return new bootstrap.Modal(modal.childNodes[0], {});
+    return new bootstrap.Modal(modal, {});
 }


### PR DESCRIPTION

# Description

Fixes a cross-site scripting (XSS) vulnerability in the modal helper. The modal was previously constructed
using string templates and `innerHTML`, which allowed injected HTML (for example `<script>` tags or
`onerror` attributes) to execute. This change refactors the modal to build its DOM using the existing
`elem()` helper and `document.createTextNode`, so user-supplied strings are inserted as plain text and
cannot execute as HTML.

Files changed:
- `javascript/UI/modal.js` — refactored to remove `innerHTML` and build modal via DOM APIs.

Motivation and context:
Using `innerHTML` with untrusted input opened the app to XSS when titles or content included malicious
markup. The refactor eliminates that attack vector while preserving the modal API. If callers require
rich HTML rendering, they should sanitize input first (e.g. DOMPurify) and pass a trusted DOM node.

Dependencies:
- No new runtime dependencies were added. (If sanitized HTML is later required, consider adding DOMPurify.)

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Manual testing on the local development server (`npm run server`) at `http://localhost:8000`.  
Verification performed by creating modals with safe strings and with known malicious payloads; observed that
malicious markup is rendered as inert text and no injected scripts or event handlers executed. 

Before test 
<img width="1472" height="1648" alt="image" src="https://github.com/user-attachments/assets/b63be3d3-503a-4f27-ad80-3ff9e3f9dc92" />

After test
<img width="1890" height="1664" alt="image" src="https://github.com/user-attachments/assets/48abb6cf-8864-45b5-bf83-1a17d99b96ef" />


## Testing Checklist

- [x] Tested in latest Chrome (manual)
- [x] Tested in latest Safari (manual)
- [ ] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
