### PR TITLE
Improve CodeMirror contrast & readability with basic WCAG standards (Dark theme)

### DIFF
--- a/javascript/UI/themes.js
+++ b/javascript/UI/themes.js
@@ -36,7 +36,7 @@ const themes = {
     "editorLineNumber": "#FFFFF0",
     "editorGutterBackground": "#dcdcdc",
     "editorString": "#fdfdfd",
-      "editorSelected": "rgba(255, 255, 255, 0.335)",
+    "editorSelected": "rgba(255, 255, 255, 0.335)",
     "editorNumber": "#BF95F9"
   },
   "professional-grey": {

--- a/javascript/UI/themes.js
+++ b/javascript/UI/themes.js
@@ -32,10 +32,12 @@ const themes = {
     //"gutterColour": "#1e1e1e",
     "shadowColour": "#1e1e1e",
     "editorKeyword": "#FAF9F6",
-    "editorComment": "#228B22",
+    "editorComment": "#25C325",
     "editorLineNumber": "#FFFFF0",
     "editorGutterBackground": "#dcdcdc",
-    "editorString": "#fdfdfd"
+    "editorString": "#fdfdfd",
+      "editorSelected": "rgba(255, 255, 255, 0.335)",
+    "editorNumber": "#BF95F9"
   },
   "professional-grey": {
     "editorBackgroundColour": "#2b2b2b",
@@ -70,7 +72,6 @@ document.addEventListener("DOMContentLoaded", () => {
   //Change the theme when the user picks something
   sel.onchange = () => applyTheme(themes[sel.value]);
 
-
   // when user picks a new theme
   sel.onchange = () => {
     const selected = sel.value;
@@ -82,6 +83,5 @@ document.addEventListener("DOMContentLoaded", () => {
       localStorage.setItem("skoTheme", selected);
     }
   };
-
 });
 


### PR DESCRIPTION
# Description

Adjusted dark theme to meet WCAG guidelines for comments numbers selections. Did not touch active line as pushing this contrast any further will break the "subtle" requirement
- Comments meet WCAG AAA pass for normal text 7.07
- selection WCAG AA graphical object and user interface components  3.03:1 
- editor number already AA but pushed to WCAG  AAA 7.05:1

made all minimal to ensure theme looks the same but with visible readability

Fixes # (issue)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration_

## Testing Checklist

- [x] Tested in latest Chrome
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
