### PR TITLE
Fix WASM binding resolution across module scopes

### DIFF
--- a/CSharpWasmExpo/main.js
+++ b/CSharpWasmExpo/main.js
@@ -9,9 +9,31 @@ const parseMethods = (methods) => {
 
   const bindingsFunctions = {};
 
+  const frame = document.querySelector("iframe");
+  const wasmScope = frame?.contentWindow;
+
   for (const name of methodList) {
     try {
-      bindingsFunctions[name] = eval(name);
+      let fn =
+        globalThis[name] ??
+        wasmScope?.[name] ??
+        wasmScope?.[`_CPP_${name}`];
+
+      if (typeof fn !== "function") {
+        const sklibMatch = Object.keys(wasmScope || {}).find(
+          (key) => key === `__sklib__${name}` || key.startsWith(`__sklib__${name}__`)
+        );
+
+        if (sklibMatch && typeof wasmScope[sklibMatch] === "function") {
+          fn = wasmScope[sklibMatch];
+        }
+      }
+
+      if (typeof fn === "function") {
+        bindingsFunctions[name] = fn;
+      } else {
+        console.warn(`Missing binding: ${name}`);
+      }
     } catch (e) {
       console.warn(e);
     }


### PR DESCRIPTION
## Summary

Generated C# WASM bindings were failing to load and initialise correctly at runtime. The lookup in `CSharpWasmExpo/main.js` that resolves each binding method against the WASM module scope only checked a single naming pattern, so methods exposed under a different scope or naming convention (e.g. `__sklib_`-prefixed keys) were silently missed.

## Change

Updated the binding resolution logic in `CSharpWasmExpo/main.js` to fall back through multiple lookup strategies when resolving a binding function:

1. `globalThis[name]`
2. `wasmScope[name]`
3. `wasmScope["_CPP_" + name]`
4. A `wasmScope` key that starts with `__sklib_` and matches the target name

This mirrors how the underlying SplashKit bindings are actually exposed across the different generated/module scopes, rather than assuming a single fixed pattern.

## Testing

- Re-tested binding loading across the CSharpWasm and CSharpWasmExpo projects to confirm bindings now resolve and initialise correctly.
- Exercised edge-case scenarios (bindings exposed under the `__sklib_` prefix and via the iframe-scoped `wasmScope`) to confirm the fallback resolves them without regressing previously-working lookups.

## Scope

This PR only touches `CSharpWasmExpo/main.js`. No build artifacts or generated files are included.